### PR TITLE
Added Group Shape Fill options

### DIFF
--- a/pptx/dml/fill.py
+++ b/pptx/dml/fill.py
@@ -150,6 +150,17 @@ class FillFormat(object):
         solidFill = self._xPr.get_or_change_to_solidFill()
         self._fill = _SolidFill(solidFill)
 
+    def group(self):
+        """
+        Sets the fill type to group, i.e. it matches the fill defined by
+        the parent group shape.
+        """
+
+        groupFill = self._+xPr.get_or_change_to_grpFill
+        self._fill = _GrpFill(groupFill)
+
+
+
     @property
     def type(self):
         """

--- a/pptx/dml/fill.py
+++ b/pptx/dml/fill.py
@@ -156,7 +156,7 @@ class FillFormat(object):
         the parent group shape.
         """
 
-        groupFill = self._+xPr.get_or_change_to_grpFill
+        groupFill = self._xPr.get_or_change_to_grpFill()
         self._fill = _GrpFill(groupFill)
 
 

--- a/pptx/oxml/shapes/groupshape.py
+++ b/pptx/oxml/shapes/groupshape.py
@@ -280,7 +280,7 @@ class CT_GroupShapeProperties(BaseOxmlElement):
         "a:extLst",
     )
     xfrm = ZeroOrOne("a:xfrm", successors=_tag_seq[1:])
-    eg_lineFillProperties = ZeroOrOneChoice(
+    eg_fillProperties = ZeroOrOneChoice(
         (
             Choice("a:noFill"),
             Choice("a:solidFill"),
@@ -300,4 +300,4 @@ class CT_GroupShapeProperties(BaseOxmlElement):
         """
         Required to fulfill the interface used by dml.fill.
         """
-        return self.eg_lineFillProperties
+        return self.eg_fillProperties

--- a/pptx/oxml/shapes/groupshape.py
+++ b/pptx/oxml/shapes/groupshape.py
@@ -274,5 +274,24 @@ class CT_GroupShapeProperties(BaseOxmlElement):
         "a:extLst",
     )
     xfrm = ZeroOrOne("a:xfrm", successors=_tag_seq[1:])
+    eg_lineFillProperties = ZeroOrOneChoice(
+        (
+            Choice("a:noFill"),
+            Choice("a:solidFill"),
+            Choice("a:gradFill"),
+            Choice("a:blipFill"),
+            Choice("a:pattFill"),
+            Choice("a:grpFill"),
+        ),
+        successors=_tag_seq[7:],
+    )
+
     effectLst = ZeroOrOne("a:effectLst", successors=_tag_seq[8:])
     del _tag_seq
+    
+    @property
+    def eg_fillProperties(self):
+        """
+        Required to fulfill the interface used by dml.fill.
+        """
+        return self.eg_lineFillProperties

--- a/pptx/oxml/shapes/groupshape.py
+++ b/pptx/oxml/shapes/groupshape.py
@@ -12,7 +12,13 @@ from pptx.oxml.shapes.connector import CT_Connector
 from pptx.oxml.shapes.graphfrm import CT_GraphicalObjectFrame
 from pptx.oxml.shapes.picture import CT_Picture
 from pptx.oxml.shapes.shared import BaseShapeElement
-from pptx.oxml.xmlchemy import BaseOxmlElement, OneAndOnlyOne, ZeroOrOne
+from pptx.oxml.xmlchemy import (
+    BaseOxmlElement,
+    OneAndOnlyOne,
+    ZeroOrOne,
+    ZeroOrOneChoice,
+    Choice,
+)
 from pptx.util import Emu
 
 

--- a/pptx/oxml/shapes/groupshape.py
+++ b/pptx/oxml/shapes/groupshape.py
@@ -280,7 +280,7 @@ class CT_GroupShapeProperties(BaseOxmlElement):
         "a:extLst",
     )
     xfrm = ZeroOrOne("a:xfrm", successors=_tag_seq[1:])
-    eg_fillProperties = ZeroOrOneChoice(
+    eg_grpFillProperties = ZeroOrOneChoice(
         (
             Choice("a:noFill"),
             Choice("a:solidFill"),
@@ -300,4 +300,4 @@ class CT_GroupShapeProperties(BaseOxmlElement):
         """
         Required to fulfill the interface used by dml.fill.
         """
-        return self.eg_fillProperties
+        return self.eg_grpFillProperties

--- a/pptx/shapes/group.py
+++ b/pptx/shapes/group.py
@@ -59,3 +59,11 @@ class GroupShape(BaseShape):
         from pptx.shapes.shapetree import GroupShapes
 
         return GroupShapes(self._element, self)
+
+    @lazyproperty
+    def fill(self):
+        """
+        |FillFormat| instance for this shape, providing access to fill
+        properties such as fill color.
+        """
+        return FillFormat.from_fill_parent(self._element.grpSpPr)

--- a/pptx/shapes/group.py
+++ b/pptx/shapes/group.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from pptx.dml.fill import FillFormat
 from pptx.dml.effect import ShadowFormat
 from pptx.enum.shapes import MSO_SHAPE_TYPE
 from pptx.shapes.base import BaseShape


### PR DESCRIPTION
This has two components, first is accessing the fill properties from the GroupShape class and then second is to add a `.group()` option to the `FillFormat` object to allow the shape to be designated as having a group fill.