### PR TITLE
DB-937 - System Color Integration

### DIFF
--- a/pptx/dml/color.py
+++ b/pptx/dml/color.py
@@ -196,7 +196,7 @@ class _Color(object):
         """
         Raises TypeError on access unless overridden by subclass.
         """
-        return MSO_THEME_COLOR.NOT_SYSTEM_COLOR
+        return None
 
     def _shade(self, value):
         lumMod_val = 1.0 - abs(value)

--- a/pptx/dml/color.py
+++ b/pptx/dml/color.py
@@ -120,7 +120,7 @@ class ColorFormat(object):
     def system_color(self, value):
         # Change to System color format if not already
         if not isinstance(self._color, _SysColor):
-            sysColor = self._xFill.get_or_change_to_sysColor()
+            sysColor = self._xFill.get_or_change_to_sysClr()
             self._color = _SysColor(sysColor)
         self._color.system_color = value
     
@@ -310,7 +310,7 @@ class _SysColor(_Color):
     def system_color(self, value):
         """
         """
-        self._sysClor.val = value
+        self._sysClr.val = value
 
 
 

--- a/pptx/dml/color.py
+++ b/pptx/dml/color.py
@@ -109,7 +109,21 @@ class ColorFormat(object):
                 " or .theme_color first."
             )
             raise ValueError(msg)
-
+    
+    @property
+    def system_color(self):
+        """ System color value for this color.
+        """
+        return self._color.system_color
+    
+    @system_color.setter
+    def system_color(self, value):
+        # Change to System color format if not already
+        if not isinstance(self._color, _SysColor):
+            sysColor = self._xFill.get_or_change_to_sysColor()
+            self._color = _SysColor(sysColor)
+        self._color.system_color = value
+    
 
 class _Color(object):
     """
@@ -176,6 +190,13 @@ class _Color(object):
         Raises TypeError on access unless overridden by subclass.
         """
         return MSO_THEME_COLOR.NOT_THEME_COLOR
+
+    @property
+    def system_color(self):
+        """
+        Raises TypeError on access unless overridden by subclass.
+        """
+        return MSO_THEME_COLOR.NOT_SYSTEM_COLOR
 
     def _shade(self, value):
         lumMod_val = 1.0 - abs(value)
@@ -271,9 +292,27 @@ class _SRgbColor(_Color):
 
 
 class _SysColor(_Color):
+    def __init__(self, sysClr):
+        super(_SysColor, self).__init__(sysClr)
+        self._sysClr = sysClr
+
     @property
     def color_type(self):
         return MSO_COLOR_TYPE.SYSTEM
+    
+    @property
+    def system_color(self):
+        """
+        """
+        return self._sysClr.val
+    
+    @system_color.setter
+    def system_color(self, value):
+        """
+        """
+        self._sysClor.val = value
+
+
 
 
 class RGBColor(tuple):

--- a/pptx/oxml/dml/color.py
+++ b/pptx/oxml/dml/color.py
@@ -7,7 +7,7 @@ lxml custom element classes for DrawingML-related XML elements.
 from __future__ import absolute_import
 
 from ...enum.dml import MSO_THEME_COLOR
-from ..simpletypes import ST_HexColorRGB, ST_Percentage
+from ..simpletypes import ST_HexColorRGB, ST_Percentage, ST_SystemColorVal
 from ..xmlchemy import (
     BaseOxmlElement,
     Choice,
@@ -113,3 +113,4 @@ class CT_SystemColor(_BaseColorElement):
     """
     Custom element class for <a:sysClr> element.
     """
+    val = RequiredAttribute("val", ST_SystemColorVal)

--- a/pptx/oxml/simpletypes.py
+++ b/pptx/oxml/simpletypes.py
@@ -797,3 +797,44 @@ class ST_TextBulletSizePercent(ST_Percentage):
     @classmethod
     def validate(cls, value):
         cls.validate_float_in_range(value, .25, 4)
+
+
+class ST_SystemColorVal(XsdTokenEnumeration):
+    """
+    Valid values for system color attribute
+    """
+    color_values = (
+        "scrollBar",
+        "background",
+        "activeCaption",
+        "inactiveCaption",
+        "menu",
+        "window",
+        "windowFrame",
+        "menuText",
+        "windowText",
+        "captionText",
+        "activeBorder",
+        "inactiveBorder",
+        "appWorkspace",
+        "highlight",
+        "highlightText",
+        "btnFace",
+        "btnShadow",
+        "grayText",
+        "btnText",
+        "inactiveCaptionText",
+        "btnHighlight",
+        "3dDkShadow",
+        "3dLight",
+        "infoText",
+        "infoBk",
+        "hotLight",
+        "gradientActiveCaption",
+        "gradientInactiveCaption",
+        "menuHighlight",
+        "menuBar"
+    )
+
+    _members = color_values
+


### PR DESCRIPTION
Apparently you can define colors in Powerpoint to be whatever the system has defined as a wide variety of options.  I think this lets things like the OS's Dark mode work.  I'm not sure.  I found it was being used and needed to be included for our importer.

This should include any required updates and unit tests.