### PR TITLE
DB-942 - Slide Layout follows master background

### DIFF
--- a/pptx/oxml/slide.py
+++ b/pptx/oxml/slide.py
@@ -259,6 +259,12 @@ class CT_SlideLayout(_BaseSlideElement):
     _tag_seq = ("p:cSld", "p:clrMapOvr", "p:transition", "p:timing", "p:hf", "p:extLst")
     cSld = OneAndOnlyOne("p:cSld")
     del _tag_seq
+    
+    @property
+    def bg(self):
+        """Return `p:bg` grandchild or None if not present."""
+        return self.cSld.bg
+
 
 
 class CT_SlideLayoutIdList(BaseOxmlElement):

--- a/pptx/slide.py
+++ b/pptx/slide.py
@@ -368,6 +368,19 @@ class SlideLayout(_BaseSlide):
         slides = self.part.package.presentation_part.presentation.slides
         return tuple(s for s in slides if s.slide_layout == self)
 
+    @property
+    def follow_master_background(self):
+        """|True| if this slide inherits the slide master background.
+
+        Assigning |False| causes background inheritance from the master to be
+        interrupted; if there is no custom background for this slide,
+        a default background is added. If a custom background already exists
+        for this slide, assigning |False| has no effect.
+
+        Assigning |True| causes any custom background for this slide to be
+        deleted and inheritance from the master restored.
+        """
+        return self._element.bg is None
 
 class SlideLayouts(ParentedElementProxy):
     """Sequence of slide layouts belonging to a slide-master.

--- a/tests/test_slide.py
+++ b/tests/test_slide.py
@@ -642,6 +642,12 @@ class DescribeSlideLayout(object):
         slide_master = slide_layout.slide_master
 
         assert slide_master is slide_master_
+    
+    def it_knows_whether_it_follows_the_mstr_bkgd(self, follow_get_fixture):
+        slide, expected_value = follow_get_fixture
+        follows = slide.follow_master_background
+        assert follows is expected_value
+
 
     def it_knows_which_slides_are_based_on_it(
         self,
@@ -694,6 +700,13 @@ class DescribeSlideLayout(object):
         presentation_.slides = slides
         expected_value = tuple(s for i, s in enumerate(slides) if i in used_by_idxs)
         return presentation_, slide_layout, expected_value
+
+    @pytest.fixture(params=[("p:sld/p:cSld", True), ("p:sld/p:cSld/p:bg", False)])
+    def follow_get_fixture(self, request):
+        pSld_cxml, expected_value = request.param
+        slide = Slide(element(pSld_cxml), None)
+        return slide, expected_value
+
 
     # fixture components -----------------------------------
 


### PR DESCRIPTION
This was pretty simple, basicaly just moving a property that was currently only available for the slide object andadding it to the slide layout.