### PR TITLE
DB-1050 - Theme Integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.8.7
+      - image: circleci/python:3.9.2
     steps:
       - checkout
       - run:

--- a/Pipfile
+++ b/Pipfile
@@ -16,4 +16,4 @@ XlsxWriter = ">=0.5.7"
 [dev-packages]
 
 [requires]
-python_version = "3.7"
+python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8010e169f2bae19c321e37426f07ab9a3511d7acc54f23cf26eacc4452983bc7"
+            "sha256": "c06d7c86fc4678f3007d1d84f31ebd83c6e20d24ec65aa324d45fc804db55799"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "2.7"
+            "python_version": "3.9"
         },
         "sources": [
             {
@@ -34,11 +34,11 @@
         },
         "flake8": {
             "hashes": [
-                "sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839",
-                "sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b"
+                "sha256:12d05ab02614b6aee8df7c36b97d1a3b2372761222b19b58621355e82acddcff",
+                "sha256:78873e372b12b093da7b5e5ed302e8ad9e988b38b063b61ad937f26ca58fc5f0"
             ],
             "index": "pypi",
-            "version": "==3.8.4"
+            "version": "==3.9.0"
         },
         "iniconfig": {
             "hashes": [
@@ -49,46 +49,45 @@
         },
         "lxml": {
             "hashes": [
-                "sha256:0448576c148c129594d890265b1a83b9cd76fd1f0a6a04620753d9a6bcfd0a4d",
-                "sha256:127f76864468d6630e1b453d3ffbbd04b024c674f55cf0a30dc2595137892d37",
-                "sha256:1471cee35eba321827d7d53d104e7b8c593ea3ad376aa2df89533ce8e1b24a01",
-                "sha256:2363c35637d2d9d6f26f60a208819e7eafc4305ce39dc1d5005eccc4593331c2",
-                "sha256:2e5cc908fe43fe1aa299e58046ad66981131a66aea3129aac7770c37f590a644",
-                "sha256:2e6fd1b8acd005bd71e6c94f30c055594bbd0aa02ef51a22bbfa961ab63b2d75",
-                "sha256:366cb750140f221523fa062d641393092813b81e15d0e25d9f7c6025f910ee80",
-                "sha256:42ebca24ba2a21065fb546f3e6bd0c58c3fe9ac298f3a320147029a4850f51a2",
-                "sha256:4e751e77006da34643ab782e4a5cc21ea7b755551db202bc4d3a423b307db780",
-                "sha256:4fb85c447e288df535b17ebdebf0ec1cf3a3f1a8eba7e79169f4f37af43c6b98",
-                "sha256:50c348995b47b5a4e330362cf39fc503b4a43b14a91c34c83b955e1805c8e308",
-                "sha256:535332fe9d00c3cd455bd3dd7d4bacab86e2d564bdf7606079160fa6251caacf",
-                "sha256:535f067002b0fd1a4e5296a8f1bf88193080ff992a195e66964ef2a6cfec5388",
-                "sha256:5be4a2e212bb6aa045e37f7d48e3e1e4b6fd259882ed5a00786f82e8c37ce77d",
-                "sha256:60a20bfc3bd234d54d49c388950195d23a5583d4108e1a1d47c9eef8d8c042b3",
-                "sha256:648914abafe67f11be7d93c1a546068f8eff3c5fa938e1f94509e4a5d682b2d8",
-                "sha256:681d75e1a38a69f1e64ab82fe4b1ed3fd758717bed735fb9aeaa124143f051af",
-                "sha256:68a5d77e440df94011214b7db907ec8f19e439507a70c958f750c18d88f995d2",
-                "sha256:69a63f83e88138ab7642d8f61418cf3180a4d8cd13995df87725cb8b893e950e",
-                "sha256:6e4183800f16f3679076dfa8abf2db3083919d7e30764a069fb66b2b9eff9939",
-                "sha256:6fd8d5903c2e53f49e99359b063df27fdf7acb89a52b6a12494208bf61345a03",
-                "sha256:791394449e98243839fa822a637177dd42a95f4883ad3dec2a0ce6ac99fb0a9d",
-                "sha256:7a7669ff50f41225ca5d6ee0a1ec8413f3a0d8aa2b109f86d540887b7ec0d72a",
-                "sha256:7e9eac1e526386df7c70ef253b792a0a12dd86d833b1d329e038c7a235dfceb5",
-                "sha256:7ee8af0b9f7de635c61cdd5b8534b76c52cd03536f29f51151b377f76e214a1a",
-                "sha256:8246f30ca34dc712ab07e51dc34fea883c00b7ccb0e614651e49da2c49a30711",
-                "sha256:8c88b599e226994ad4db29d93bc149aa1aff3dc3a4355dd5757569ba78632bdf",
-                "sha256:923963e989ffbceaa210ac37afc9b906acebe945d2723e9679b643513837b089",
-                "sha256:94d55bd03d8671686e3f012577d9caa5421a07286dd351dfef64791cf7c6c505",
-                "sha256:97db258793d193c7b62d4e2586c6ed98d51086e93f9a3af2b2034af01450a74b",
-                "sha256:a9d6bc8642e2c67db33f1247a77c53476f3a166e09067c0474facb045756087f",
-                "sha256:cd11c7e8d21af997ee8079037fff88f16fda188a9776eb4b81c7e4c9c0a7d7fc",
-                "sha256:d8d3d4713f0c28bdc6c806a278d998546e8efc3498949e3ace6e117462ac0a5e",
-                "sha256:e0bfe9bb028974a481410432dbe1b182e8191d5d40382e5b8ff39cdd2e5c5931",
-                "sha256:f4822c0660c3754f1a41a655e37cb4dbbc9be3d35b125a37fab6f82d47674ebc",
-                "sha256:f83d281bb2a6217cd806f4cf0ddded436790e66f393e124dfe9731f6b3fb9afe",
-                "sha256:fc37870d6716b137e80d19241d0e2cff7a7643b925dfa49b4c8ebd1295eb506e"
+                "sha256:079f3ae844f38982d156efce585bc540c16a926d4436712cf4baee0cce487a3d",
+                "sha256:0fbcf5565ac01dff87cbfc0ff323515c823081c5777a9fc7703ff58388c258c3",
+                "sha256:122fba10466c7bd4178b07dba427aa516286b846b2cbd6f6169141917283aae2",
+                "sha256:1b7584d421d254ab86d4f0b13ec662a9014397678a7c4265a02a6d7c2b18a75f",
+                "sha256:26e761ab5b07adf5f555ee82fb4bfc35bf93750499c6c7614bd64d12aaa67927",
+                "sha256:289e9ca1a9287f08daaf796d96e06cb2bc2958891d7911ac7cae1c5f9e1e0ee3",
+                "sha256:2a9d50e69aac3ebee695424f7dbd7b8c6d6eb7de2a2eb6b0f6c7db6aa41e02b7",
+                "sha256:33bb934a044cf32157c12bfcfbb6649807da20aa92c062ef51903415c704704f",
+                "sha256:3439c71103ef0e904ea0a1901611863e51f50b5cd5e8654a151740fde5e1cade",
+                "sha256:39b78571b3b30645ac77b95f7c69d1bffc4cf8c3b157c435a34da72e78c82468",
+                "sha256:4289728b5e2000a4ad4ab8da6e1db2e093c63c08bdc0414799ee776a3f78da4b",
+                "sha256:4bff24dfeea62f2e56f5bab929b4428ae6caba2d1eea0c2d6eb618e30a71e6d4",
+                "sha256:542d454665a3e277f76954418124d67516c5f88e51a900365ed54a9806122b83",
+                "sha256:5a0a14e264069c03e46f926be0d8919f4105c1623d620e7ec0e612a2e9bf1c04",
+                "sha256:66e575c62792c3f9ca47cb8b6fab9e35bab91360c783d1606f758761810c9791",
+                "sha256:74f7d8d439b18fa4c385f3f5dfd11144bb87c1da034a466c5b5577d23a1d9b51",
+                "sha256:7610b8c31688f0b1be0ef882889817939490a36d0ee880ea562a4e1399c447a1",
+                "sha256:76fa7b1362d19f8fbd3e75fe2fb7c79359b0af8747e6f7141c338f0bee2f871a",
+                "sha256:7728e05c35412ba36d3e9795ae8995e3c86958179c9770e65558ec3fdfd3724f",
+                "sha256:8157dadbb09a34a6bd95a50690595e1fa0af1a99445e2744110e3dca7831c4ee",
+                "sha256:820628b7b3135403540202e60551e741f9b6d3304371712521be939470b454ec",
+                "sha256:884ab9b29feaca361f7f88d811b1eea9bfca36cf3da27768d28ad45c3ee6f969",
+                "sha256:89b8b22a5ff72d89d48d0e62abb14340d9e99fd637d046c27b8b257a01ffbe28",
+                "sha256:92e821e43ad382332eade6812e298dc9701c75fe289f2a2d39c7960b43d1e92a",
+                "sha256:b007cbb845b28db4fb8b6a5cdcbf65bacb16a8bd328b53cbc0698688a68e1caa",
+                "sha256:bc4313cbeb0e7a416a488d72f9680fffffc645f8a838bd2193809881c67dd106",
+                "sha256:bccbfc27563652de7dc9bdc595cb25e90b59c5f8e23e806ed0fd623755b6565d",
+                "sha256:c4f05c5a7c49d2fb70223d0d5bcfbe474cf928310ac9fa6a7c6dddc831d0b1d4",
+                "sha256:ce256aaa50f6cc9a649c51be3cd4ff142d67295bfc4f490c9134d0f9f6d58ef0",
+                "sha256:d2e35d7bf1c1ac8c538f88d26b396e73dd81440d59c1ef8522e1ea77b345ede4",
+                "sha256:df7c53783a46febb0e70f6b05df2ba104610f2fb0d27023409734a3ecbb78fb2",
+                "sha256:efac139c3f0bf4f0939f9375af4b02c5ad83a622de52d6dfa8e438e8e01d0eb0",
+                "sha256:efd7a09678fd8b53117f6bae4fa3825e0a22b03ef0a932e070c0bdbb3a35e654",
+                "sha256:f2380a6376dfa090227b663f9678150ef27543483055cc327555fb592c5967e2",
+                "sha256:f8380c03e45cf09f8557bdaa41e1fa7c81f3ae22828e1db470ab2a6c96d8bc23",
+                "sha256:f90ba11136bfdd25cae3951af8da2e95121c9b9b93727b1b896e3fa105b2f586"
             ],
             "index": "pypi",
-            "version": "==4.6.2"
+            "version": "==4.6.3"
         },
         "mccabe": {
             "hashes": [
@@ -124,46 +123,47 @@
                 "sha256:089a471b06327103865dfec2dd844230c3c658a4a1b5b4c8b6c16c8f77577f9e",
                 "sha256:7f690b18d35048c15438d6d0571f9045cffbec5907e0b1ccf006f889e3a38c0b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.5.2"
         },
         "pillow": {
             "hashes": [
-                "sha256:165c88bc9d8dba670110c689e3cc5c71dbe4bfb984ffa7cbebf1fac9554071d6",
-                "sha256:1d208e670abfeb41b6143537a681299ef86e92d2a3dac299d3cd6830d5c7bded",
-                "sha256:22d070ca2e60c99929ef274cfced04294d2368193e935c5d6febfd8b601bf865",
-                "sha256:2353834b2c49b95e1313fb34edf18fca4d57446675d05298bb694bca4b194174",
-                "sha256:39725acf2d2e9c17356e6835dccebe7a697db55f25a09207e38b835d5e1bc032",
-                "sha256:3de6b2ee4f78c6b3d89d184ade5d8fa68af0848f9b6b6da2b9ab7943ec46971a",
-                "sha256:47c0d93ee9c8b181f353dbead6530b26980fe4f5485aa18be8f1fd3c3cbc685e",
-                "sha256:5e2fe3bb2363b862671eba632537cd3a823847db4d98be95690b7e382f3d6378",
-                "sha256:604815c55fd92e735f9738f65dabf4edc3e79f88541c221d292faec1904a4b17",
-                "sha256:6c5275bd82711cd3dcd0af8ce0bb99113ae8911fc2952805f1d012de7d600a4c",
-                "sha256:731ca5aabe9085160cf68b2dbef95fc1991015bc0a3a6ea46a371ab88f3d0913",
-                "sha256:7612520e5e1a371d77e1d1ca3a3ee6227eef00d0a9cddb4ef7ecb0b7396eddf7",
-                "sha256:7916cbc94f1c6b1301ac04510d0881b9e9feb20ae34094d3615a8a7c3db0dcc0",
-                "sha256:81c3fa9a75d9f1afafdb916d5995633f319db09bd773cb56b8e39f1e98d90820",
-                "sha256:887668e792b7edbfb1d3c9d8b5d8c859269a0f0eba4dda562adb95500f60dbba",
-                "sha256:93a473b53cc6e0b3ce6bf51b1b95b7b1e7e6084be3a07e40f79b42e83503fbf2",
-                "sha256:96d4dc103d1a0fa6d47c6c55a47de5f5dafd5ef0114fa10c85a1fd8e0216284b",
-                "sha256:a3d3e086474ef12ef13d42e5f9b7bbf09d39cf6bd4940f982263d6954b13f6a9",
-                "sha256:b02a0b9f332086657852b1f7cb380f6a42403a6d9c42a4c34a561aa4530d5234",
-                "sha256:b09e10ec453de97f9a23a5aa5e30b334195e8d2ddd1ce76cc32e52ba63c8b31d",
-                "sha256:b6f00ad5ebe846cc91763b1d0c6d30a8042e02b2316e27b05de04fa6ec831ec5",
-                "sha256:bba80df38cfc17f490ec651c73bb37cd896bc2400cfba27d078c2135223c1206",
-                "sha256:c3d911614b008e8a576b8e5303e3db29224b455d3d66d1b2848ba6ca83f9ece9",
-                "sha256:ca20739e303254287138234485579b28cb0d524401f83d5129b5ff9d606cb0a8",
-                "sha256:cb192176b477d49b0a327b2a5a4979552b7a58cd42037034316b8018ac3ebb59",
-                "sha256:cdbbe7dff4a677fb555a54f9bc0450f2a21a93c5ba2b44e09e54fcb72d2bd13d",
-                "sha256:cf6e33d92b1526190a1de904df21663c46a456758c0424e4f947ae9aa6088bf7",
-                "sha256:d355502dce85ade85a2511b40b4c61a128902f246504f7de29bbeec1ae27933a",
-                "sha256:d673c4990acd016229a5c1c4ee8a9e6d8f481b27ade5fc3d95938697fa443ce0",
-                "sha256:dc577f4cfdda354db3ae37a572428a90ffdbe4e51eda7849bf442fb803f09c9b",
-                "sha256:dd9eef866c70d2cbbea1ae58134eaffda0d4bfea403025f4db6859724b18ab3d",
-                "sha256:f50e7a98b0453f39000619d845be8b06e611e56ee6e8186f7f60c3b1e2f0feae"
+                "sha256:15306d71a1e96d7e271fd2a0737038b5a92ca2978d2e38b6ced7966583e3d5af",
+                "sha256:1940fc4d361f9cc7e558d6f56ff38d7351b53052fd7911f4b60cd7bc091ea3b1",
+                "sha256:1f93f2fe211f1ef75e6f589327f4d4f8545d5c8e826231b042b483d8383e8a7c",
+                "sha256:30d33a1a6400132e6f521640dd3f64578ac9bfb79a619416d7e8802b4ce1dd55",
+                "sha256:328240f7dddf77783e72d5ed79899a6b48bc6681f8d1f6001f55933cb4905060",
+                "sha256:46c2bcf8e1e75d154e78417b3e3c64e96def738c2a25435e74909e127a8cba5e",
+                "sha256:5762ebb4436f46b566fc6351d67a9b5386b5e5de4e58fdaa18a1c83e0e20f1a8",
+                "sha256:5a2d957eb4aba9d48170b8fe6538ec1fbc2119ffe6373782c03d8acad3323f2e",
+                "sha256:5cf03b9534aca63b192856aa601c68d0764810857786ea5da652581f3a44c2b0",
+                "sha256:5daba2b40782c1c5157a788ec4454067c6616f5a0c1b70e26ac326a880c2d328",
+                "sha256:63cd413ac52ee3f67057223d363f4f82ce966e64906aea046daf46695e3c8238",
+                "sha256:6efac40344d8f668b6c4533ae02a48d52fd852ef0654cc6f19f6ac146399c733",
+                "sha256:71b01ee69e7df527439d7752a2ce8fb89e19a32df484a308eca3e81f673d3a03",
+                "sha256:71f31ee4df3d5e0b366dd362007740106d3210fb6a56ec4b581a5324ba254f06",
+                "sha256:72027ebf682abc9bafd93b43edc44279f641e8996fb2945104471419113cfc71",
+                "sha256:74cd9aa648ed6dd25e572453eb09b08817a1e3d9f8d1bd4d8403d99e42ea790b",
+                "sha256:81b3716cc9744ffdf76b39afb6247eae754186838cedad0b0ac63b2571253fe6",
+                "sha256:8565355a29655b28fdc2c666fd9a3890fe5edc6639d128814fafecfae2d70910",
+                "sha256:87f42c976f91ca2fc21a3293e25bd3cd895918597db1b95b93cbd949f7d019ce",
+                "sha256:89e4c757a91b8c55d97c91fa09c69b3677c227b942fa749e9a66eef602f59c28",
+                "sha256:8c4e32218c764bc27fe49b7328195579581aa419920edcc321c4cb877c65258d",
+                "sha256:903293320efe2466c1ab3509a33d6b866dc850cfd0c5d9cc92632014cec185fb",
+                "sha256:90882c6f084ef68b71bba190209a734bf90abb82ab5e8f64444c71d5974008c6",
+                "sha256:98afcac3205d31ab6a10c5006b0cf040d0026a68ec051edd3517b776c1d78b09",
+                "sha256:a01da2c266d9868c4f91a9c6faf47a251f23b9a862dce81d2ff583135206f5be",
+                "sha256:aeab4cd016e11e7aa5cfc49dcff8e51561fa64818a0be86efa82c7038e9369d0",
+                "sha256:b07c660e014852d98a00a91adfbe25033898a9d90a8f39beb2437d22a203fc44",
+                "sha256:bead24c0ae3f1f6afcb915a057943ccf65fc755d11a1410a909c1fefb6c06ad1",
+                "sha256:d1d6bca39bb6dd94fba23cdb3eeaea5e30c7717c5343004d900e2a63b132c341",
+                "sha256:e2cd8ac157c1e5ae88b6dd790648ee5d2777e76f1e5c7d184eaddb2938594f34",
+                "sha256:e5739ae63636a52b706a0facec77b2b58e485637e1638202556156e424a02dc2",
+                "sha256:f36c3ff63d6fc509ce599a2f5b0d0732189eed653420e7294c039d342c6e204a",
+                "sha256:f91b50ad88048d795c0ad004abbe1390aa1882073b1dca10bfd55d0b8cf18ec5"
             ],
             "index": "pypi",
-            "version": "==8.1.0"
+            "version": "==8.1.2"
         },
         "pluggy": {
             "hashes": [
@@ -183,19 +183,19 @@
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367",
-                "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"
+                "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068",
+                "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.6.0"
+            "version": "==2.7.0"
         },
         "pyflakes": {
             "hashes": [
-                "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92",
-                "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"
+                "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3",
+                "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.2.0"
+            "version": "==2.3.1"
         },
         "pyparsing": {
             "hashes": [
@@ -218,7 +218,7 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
         "toml": {
@@ -226,7 +226,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
         },
         "xlsxwriter": {

--- a/pptx/__init__.py
+++ b/pptx/__init__.py
@@ -26,6 +26,7 @@ from pptx.parts.slide import (  # noqa: E402
     SlideLayoutPart,
     SlideMasterPart,
     SlidePart,
+    ThemePart,
 )
 
 content_type_to_part_class_map = {
@@ -39,6 +40,7 @@ content_type_to_part_class_map = {
     CT.PML_SLIDE: SlidePart,
     CT.PML_SLIDE_LAYOUT: SlideLayoutPart,
     CT.PML_SLIDE_MASTER: SlideMasterPart,
+    CT.OFC_THEME: ThemePart,
     CT.DML_CHART: ChartPart,
     CT.BMP: ImagePart,
     CT.GIF: ImagePart,

--- a/pptx/dml/border.py
+++ b/pptx/dml/border.py
@@ -4,10 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from ..enum.dml import MSO_FILL
-from .fill import FillFormat
 from .line import LineFormat
-from ..util import Emu, lazyproperty
 
 
 class BorderFormat(LineFormat):

--- a/pptx/dml/line.py
+++ b/pptx/dml/line.py
@@ -100,3 +100,68 @@ class LineFormat(object):
     @property
     def _ln(self):
         return self._parent.ln
+
+
+
+class LineStyle(object):
+    """Provides access to line properties such as color, style, and width.
+
+    While LineFormat is accessed from the parent, this is accessed directly
+    and LineFormat is read only.  It is used in the Themes
+    """
+
+    def __init__(self, ln):
+        super(LineStyle, self).__init__()
+        self._ln = ln
+
+    @lazyproperty
+    def color(self):
+        """
+        The |ColorFormat| instance that provides access to the color settings
+        for this line. Essentially a shortcut for ``line.fill.fore_color``.
+        As a side-effect, accessing this property causes the line fill type
+        to be set to ``MSO_FILL.SOLID``. If this sounds risky for your use
+        case, use ``line.fill.type`` to non-destructively discover the
+        existing fill type.
+        """
+        if self.fill.type != MSO_FILL.SOLID:
+            self.fill.solid()
+        return self.fill.fore_color
+
+    @property
+    def dash_style(self):
+        """Return value indicating line style.
+
+        Returns a member of :ref:`MsoLineDashStyle` indicating line style, or
+        |None| if no explicit value has been set. When no explicit value has
+        been set, the line dash style is inherited from the style hierarchy.
+
+        Assigning |None| removes any existing explicitly-defined dash style.
+        """
+        ln = self._ln
+        if ln is None:
+            return None
+        return ln.prstDash_val
+
+    @lazyproperty
+    def fill(self):
+        """
+        |FillFormat| instance for this line, providing access to fill
+        properties such as foreground color.
+        """
+        ln = self._ln
+        return FillFormat.from_fill_parent(ln)
+
+    @property
+    def width(self):
+        """
+        The width of the line expressed as an integer number of :ref:`English
+        Metric Units <EMU>`. The returned value is an instance of |Length|,
+        a value class having properties such as `.inches`, `.cm`, and `.pt`
+        for converting the value into convenient units.
+        """
+        ln = self._ln
+        if ln is None:
+            return Emu(0)
+        return ln.w
+

--- a/pptx/dml/line.py
+++ b/pptx/dml/line.py
@@ -107,7 +107,7 @@ class LineStyle(object):
     """Provides access to line properties such as color, style, and width.
 
     While LineFormat is accessed from the parent, this is accessed directly
-    and LineFormat is read only.  It is used in the Themes
+    and LineStyle is read only.  It is used in the Themes
     """
 
     def __init__(self, ln):

--- a/pptx/oxml/__init__.py
+++ b/pptx/oxml/__init__.py
@@ -482,6 +482,8 @@ from .text import (  # noqa: E402
     CT_TextNoBullet,
     CT_TextBulletTypefaceFollowText,
     CT_TextBlipBullet,
+    CT_FontCollection,
+    CT_SupplementalFont,
 )
 
 register_element_cls("a:bodyPr", CT_TextBodyProperties)
@@ -515,8 +517,37 @@ register_element_cls("a:spcPts", CT_TextSpacingPoint)
 register_element_cls("a:txBody", CT_TextBody)
 register_element_cls("c:txPr", CT_TextBody)
 register_element_cls("p:txBody", CT_TextBody)
+register_element_cls("a:ea", CT_TextFont)
+register_element_cls("a:cs", CT_TextFont)
+register_element_cls("a:font", CT_SupplementalFont)
 
 
-from .theme import CT_OfficeStyleSheet  # noqa: E402
+
+from .theme import (
+    CT_OfficeStyleSheet,  # noqa: E402
+    CT_BaseStyles,
+    CT_ColorScheme,
+    CT_FontScheme,
+    CT_StyleMatrix,
+)
 
 register_element_cls("a:theme", CT_OfficeStyleSheet)
+register_element_cls("a:themeElements", CT_BaseStyles)
+register_element_cls("a:clrScheme", CT_ColorScheme)
+register_element_cls("a:fontScheme", CT_FontScheme)
+register_element_cls("a:fmtScheme", CT_StyleMatrix)
+register_element_cls("a:theme", CT_OfficeStyleSheet)
+register_element_cls("a:dk1", CT_Color)
+register_element_cls("a:lt1", CT_Color)
+register_element_cls("a:dk2", CT_Color)
+register_element_cls("a:lt2", CT_Color)
+register_element_cls("a:accent1", CT_Color)
+register_element_cls("a:accent2", CT_Color)
+register_element_cls("a:accent3", CT_Color)
+register_element_cls("a:accent4", CT_Color)
+register_element_cls("a:accent5", CT_Color)
+register_element_cls("a:accent6", CT_Color)
+register_element_cls("a:hlink", CT_Color)
+register_element_cls("a:folHlink", CT_Color)
+register_element_cls("a:majorFont", CT_FontCollection)
+register_element_cls("a:minorFont", CT_FontCollection)

--- a/pptx/oxml/text.py
+++ b/pptx/oxml/text.py
@@ -358,10 +358,10 @@ class CT_TextFont(BaseOxmlElement):
     elements of CT_TextCharacterProperties, e.g. <a:rPr>.
     """
 
-    typeface = RequiredAttribute("typeface", ST_TextTypeface)
-    pitchFamily = OptionalAttribute("pitchFamily", ST_TextPitchFamily)
+    typeface = OptionalAttribute("typeface", ST_TextTypeface)
+    pitchFamily = OptionalAttribute("pitchFamily", ST_TextPitchFamily, default=0)
     panose = OptionalAttribute("panose", ST_TextPanose)
-    charset = OptionalAttribute("charset", ST_TextCharset)
+    charset = OptionalAttribute("charset", ST_TextCharset, default=1)
 
 
 class CT_TextLineBreak(BaseOxmlElement):

--- a/pptx/oxml/text.py
+++ b/pptx/oxml/text.py
@@ -690,3 +690,33 @@ class CT_TextBlipBullet(BaseOxmlElement):
     NOTE: Not fully Implemented yet
     """
     blip = OneAndOnlyOne("a:blip")
+
+
+
+class CT_FontCollection(BaseOxmlElement):
+    """
+    Custom element class for <a:font>, <a:majorFont>, <a:minorFont>
+    """
+
+    _tag_seq = (
+        "a:latin",
+        "a:ea",
+        "a:cs",
+        "a:font",
+        "a:extLst",
+    )
+
+    latin = OneAndOnlyOne("a:latin")
+    ea = OneAndOnlyOne("a:ea")
+    cs = OneAndOnlyOne("a:cs")
+    font = ZeroOrMore("a:font", successors=_tag_seq[4:])
+
+
+
+class CT_SupplementalFont(BaseOxmlElement):
+    """
+    Custom Element class for supplemental fonts
+    """
+    script = RequiredAttribute("script", XsdString)
+    typeface = RequiredAttribute("typeface", ST_TextTypeface)
+

--- a/pptx/oxml/theme.py
+++ b/pptx/oxml/theme.py
@@ -7,9 +7,19 @@ lxml custom element classes for theme-related XML elements.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from . import parse_from_template
-from .xmlchemy import BaseOxmlElement
+from .xmlchemy import (
+    BaseOxmlElement,
+    RequiredAttribute,
+    OptionalAttribute,
+    OneAndOnlyOne,
+    ZeroOrMoreChoice,
+    Choice,
+    OneOrMore,
+)
 
-
+from pptx.oxml.simpletypes import (
+    XsdString
+)
 class CT_OfficeStyleSheet(BaseOxmlElement):
     """
     ``<a:theme>`` element, root of a theme part
@@ -24,6 +34,10 @@ class CT_OfficeStyleSheet(BaseOxmlElement):
     )
     del _tag_seq
 
+    theme_elements = OneAndOnlyOne("a:themeElements")
+
+    name = OptionalAttribute('name', XsdString, default="")
+
     @classmethod
     def new_default(cls):
         """
@@ -31,3 +45,114 @@ class CT_OfficeStyleSheet(BaseOxmlElement):
         suitable for use with a notes master.
         """
         return parse_from_template("theme")
+
+
+
+class CT_BaseStyles(BaseOxmlElement):
+
+    _tag_seq = (
+        "a:clrScheme",
+        "a:fontScheme",
+        "a:fmtScheme",
+        "a:extList",
+    )
+    clrScheme = OneAndOnlyOne("a:clrScheme")
+    fontScheme = OneAndOnlyOne("a:fontScheme")
+    fmtScheme = OneAndOnlyOne("a:fmtScheme")
+    
+
+class CT_ColorScheme(BaseOxmlElement):
+    
+    _tag_seq = (
+        "a:dk1",
+        "a:lt1",
+        "a:dk2",
+        "a:lt2",
+        "a:accent1",
+        "a:accent2",
+        "a:accent3",
+        "a:accent4",
+        "a:accent5",
+        "a:accent6",
+        "a:hlink",
+        "a:folHlink",
+        "a:extLst",
+    )
+
+    dk1 = OneAndOnlyOne("a:dk1")
+    lt1 = OneAndOnlyOne("a:lt1")
+    dk2 = OneAndOnlyOne("a:dk2")
+    lt2 = OneAndOnlyOne("a:lt2")
+    accent1 = OneAndOnlyOne("a:accent1")
+    accent2 = OneAndOnlyOne("a:accent2")
+    accent3 = OneAndOnlyOne("a:accent3")
+    accent4 = OneAndOnlyOne("a:accent4")
+    accent5 = OneAndOnlyOne("a:accent5")
+    accent6 = OneAndOnlyOne("a:accent6")
+    hlink = OneAndOnlyOne("a:hlink")
+    folHlink = OneAndOnlyOne("a:folHlink")
+
+    name = RequiredAttribute('name', XsdString)
+
+
+class CT_FontScheme(BaseOxmlElement):
+    _tag_seq = (
+        "a:majorFont",
+        "a:minorFont",
+        "a_extList"
+    )
+    majorFont = OneAndOnlyOne("a:majorFont")
+    minorFont = OneAndOnlyOne("a:minorFont")
+
+    name = RequiredAttribute('name', XsdString)
+
+    
+class CT_StyleMatrix(BaseOxmlElement):
+    _tag_seq = (
+        "a:fillStyleLst",
+        "a:lnStyleLst",
+        "a:effectStyleLst",
+        "a:bgFillStyleLst"
+    )
+
+    fillStyleLst = OneAndOnlyOne("a:fillStyleLst")
+    lnStyleLst = OneAndOnlyOne("a:lnStyleLst")
+    effectStyleLst = OneAndOnlyOne("a:effectStyleLst")
+    bgFillStyleLst = OneAndOnlyOne("a:bgFillStyleLst")
+
+    name = OptionalAttribute("name", XsdString, "")
+
+
+class CT_FillStyleList(BaseOxmlElement):
+    eg_fillProperties = ZeroOrMoreChoice(
+        (
+            Choice("a:noFill"),
+            Choice("a:solidFill"),
+            Choice("a:gradFill"),
+            Choice("a:blipFill"),
+            Choice("a:pattFill"),
+            Choice("a:grpFill"),
+        )
+    )
+
+
+class CT_LineStyleList(BaseOxmlElement):
+    ln = ZeroOrMoreChoice(
+        (Choice("a:ln"),)
+    )
+
+class CT_EffectStyleList(BaseOxmlElement):
+    # Not Implementing for now
+    pass
+
+class CT_BackgroundFillStyleList(BaseOxmlElement):
+    eg_fillProperties = ZeroOrMoreChoice(
+        (
+            Choice("a:noFill"),
+            Choice("a:solidFill"),
+            Choice("a:gradFill"),
+            Choice("a:blipFill"),
+            Choice("a:pattFill"),
+            Choice("a:grpFill"),
+        )
+    )

--- a/pptx/oxml/xmlchemy.py
+++ b/pptx/oxml/xmlchemy.py
@@ -720,6 +720,25 @@ class ZeroOrOneChoice(_BaseChildElement):
         return "_remove_%s" % self._prop_name
 
 
+class ZeroOrMoreChoice(ZeroOrOneChoice):
+    """
+    Used in the Theme Style Lists.  
+    Technically it should be ThreeOrMoreChoice but we are using it
+    in a readonly context so it doesnt' really matter.      
+    """
+
+    def populate_class_members(self, element_cls, prop_name):
+        """
+        Add the appropriate methods to *element_cls*.
+        """
+        super(ZeroOrMoreChoice, self).populate_class_members(element_cls, prop_name)
+        self._add_choice_getter()
+        for choice in self._choices:
+            choice.populate_class_members(
+                element_cls, self._prop_name, self._successors
+            )
+
+
 class _OxmlElementBase(etree.ElementBase):
     """
     Provides common behavior for oxml element classes

--- a/pptx/oxml/xmlchemy.py
+++ b/pptx/oxml/xmlchemy.py
@@ -724,7 +724,7 @@ class ZeroOrMoreChoice(ZeroOrOneChoice):
     """
     Used in the Theme Style Lists.  
     Technically it should be ThreeOrMoreChoice but we are using it
-    in a readonly context so it doesnt' really matter.      
+    in a readonly context so it doesn't really matter.      
     """
 
     def populate_class_members(self, element_cls, prop_name):

--- a/pptx/parts/slide.py
+++ b/pptx/parts/slide.py
@@ -13,6 +13,7 @@ from ..opc.packuri import PackURI
 from ..oxml.slide import CT_NotesMaster, CT_NotesSlide, CT_Slide
 from ..oxml.theme import CT_OfficeStyleSheet
 from ..slide import NotesMaster, NotesSlide, Slide, SlideLayout, SlideMaster
+from ..theme import Theme
 from ..util import lazyproperty
 
 
@@ -292,3 +293,26 @@ class SlideMasterPart(BaseSlidePart):
         The |SlideMaster| object representing this part.
         """
         return SlideMaster(self._element, self)
+    
+
+    def related_theme(self):
+        """
+        The |Theme| object representing this part.
+        """
+        return Theme(self.part_related_by(RT.THEME))
+    
+
+
+class ThemePart(XmlPart):
+    """
+    Theme part.  Corresponds to package files 
+    ppt/theme/theme[1-9][0-9]*.xml.
+    """
+    @property
+    def name(self):
+        return self._element.name
+
+    @property
+    def theme_elements(self):
+        return self._element.theme_elements
+

--- a/pptx/parts/slide.py
+++ b/pptx/parts/slide.py
@@ -299,9 +299,8 @@ class SlideMasterPart(BaseSlidePart):
         """
         The |Theme| object representing this part.
         """
-        return Theme(self.part_related_by(RT.THEME))
+        return self.part_related_by(RT.THEME).theme
     
-
 
 class ThemePart(XmlPart):
     """
@@ -312,7 +311,9 @@ class ThemePart(XmlPart):
     def name(self):
         return self._element.name
 
-    @property
-    def theme_elements(self):
-        return self._element.theme_elements
-
+    @lazyproperty
+    def theme(self):
+        """
+        The |Theme| object representing this part.
+        """
+        return Theme(self._element)

--- a/pptx/slide.py
+++ b/pptx/slide.py
@@ -16,6 +16,7 @@ from pptx.shapes.shapetree import (
     SlidePlaceholders,
     SlideShapes,
 )
+from pptx.theme import Theme
 from pptx.shared import ElementProxy, ParentedElementProxy, PartElementProxy
 from pptx.util import lazyproperty
 
@@ -472,6 +473,11 @@ class SlideMaster(_BaseMaster):
     def slide_layouts(self):
         """|SlideLayouts| object providing access to this slide-master's layouts."""
         return SlideLayouts(self._element.get_or_add_sldLayoutIdLst(), self)
+
+    @property
+    def theme(self):
+        """|Theme| object providing access to this slide-master's theme."""
+        return self.part.related_theme()
 
 
 class SlideMasters(ParentedElementProxy):

--- a/pptx/slide.py
+++ b/pptx/slide.py
@@ -16,7 +16,6 @@ from pptx.shapes.shapetree import (
     SlidePlaceholders,
     SlideShapes,
 )
-from pptx.theme import Theme
 from pptx.shared import ElementProxy, ParentedElementProxy, PartElementProxy
 from pptx.util import lazyproperty
 

--- a/pptx/slide.py
+++ b/pptx/slide.py
@@ -476,7 +476,7 @@ class SlideMaster(_BaseMaster):
     @property
     def theme(self):
         """|Theme| object providing access to this slide-master's theme."""
-        return self.part.related_theme()
+        return self.part.related_theme
 
 
 class SlideMasters(ParentedElementProxy):

--- a/pptx/text/text.py
+++ b/pptx/text/text.py
@@ -16,6 +16,7 @@ from pptx.text.fonts import FontFiles
 from pptx.text.layout import TextFitter
 from pptx.text.bullets import TextBullet, TextBulletColor, TextBulletSize, TextBulletTypeface
 from pptx.util import Centipoints, Emu, lazyproperty, Pt, Inches
+from pptx.shared import ElementProxy
 
 
 class TextFrame(Subshape):
@@ -831,3 +832,22 @@ class _Run(Subshape):
     @text.setter
     def text(self, str):
         self._r.text = to_unicode(str)
+
+
+class TextFont(ElementProxy):
+    @property
+    def typeface(self):
+        return self._element.typeface
+
+    @property
+    def pitch_family(self):
+        return self._element.pitchFamily
+
+    @property
+    def panose(self):
+        return self._element.panose
+    
+    @property
+    def charset(self):
+        return self._element.charset
+    

--- a/pptx/theme.py
+++ b/pptx/theme.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from pptx.shared import ElementProxy
 from pptx.dml.color import ColorFormat
 from pptx.dml.fill import FillFormat, _Fill
-from pptx.dml.line import LineFormat
+from pptx.dml.line import LineStyle
 from pptx.text.text import TextFont
 
 
@@ -135,7 +135,7 @@ class FormatScheme(ElementProxy):
         
     @property
     def line_style_list(self):
-        return []
+        return tuple([LineStyle(line) for line in self._element.lnStyleLst])
     
     @property
     def effect_style_list(self):

--- a/pptx/theme.py
+++ b/pptx/theme.py
@@ -1,0 +1,160 @@
+# encoding: utf-8
+
+"""Theme-releated objects including theme, color, font, and format schemes."""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from pptx.shared import ElementProxy
+from pptx.dml.color import ColorFormat
+from pptx.dml.fill import FillFormat, _Fill
+from pptx.dml.line import LineFormat
+from pptx.text.text import TextFont
+
+
+class Theme(ElementProxy):
+    """Provides access to the Theme associated with a MasterSlide
+
+    This is a read only object.
+    """
+    @property
+    def name(self):
+        """ Return read only access to the :attr: `name`
+        """
+        return self._element.name
+
+    @property
+    def theme_elements(self):
+        return ThemeElements(self._element.theme_elements)
+
+    @property
+    def color_scheme(self):
+        """Easy access to theme element's color_scheme"""
+
+        return self.theme_elements.color_scheme
+    
+    @property
+    def font_scheme(self):
+        """Easy access to theme elements' font_scheme"""
+        return self.theme_elements.font_scheme
+        
+    @property
+    def format_scheme(self):
+        """Easy access to theme elements' format_scheme"""
+        return self.theme_elements.format_scheme
+        
+
+class ThemeElements(ElementProxy):
+    """Provides access to the theme elements"""
+
+    @property
+    def color_scheme(self):
+        """Read Only Access to Theme's Color Scheme"""
+        return ColorScheme(self._element.clrScheme)
+    
+    @property
+    def font_scheme(self):
+        """ Read Only Access to Theme's Font Scheme"""
+        return FontScheme(self._element.fontScheme)
+
+    @property
+    def format_scheme(self):
+        """Read only access to theme's format scheme"""
+        return FormatScheme(self._element.fmtScheme)
+    
+
+class ColorScheme(ElementProxy):
+    @property
+    def name(self):
+        return self._element.name
+
+    @property
+    def dk1(self):
+        return ColorFormat.from_colorchoice_parent(self._element.dk1)
+
+    @property
+    def dk2(self):
+        return ColorFormat.from_colorchoice_parent(self._element.dk2)
+
+    @property
+    def lt1(self):
+        return ColorFormat.from_colorchoice_parent(self._element.lt1)
+
+    @property
+    def lt2(self):
+        return ColorFormat.from_colorchoice_parent(self._element.lt2)
+
+    @property
+    def accent1(self):
+        return ColorFormat.from_colorchoice_parent(self._element.accent1)
+
+    @property
+    def accent2(self):
+        return ColorFormat.from_colorchoice_parent(self._element.accent2)
+
+    @property
+    def accent3(self):
+        return ColorFormat.from_colorchoice_parent(self._element.accent3)
+
+    @property
+    def accent4(self):
+        return ColorFormat.from_colorchoice_parent(self._element.accent4)
+
+    @property
+    def accent5(self):
+        return ColorFormat.from_colorchoice_parent(self._element.accent5)
+
+    @property
+    def accent6(self):
+        return ColorFormat.from_colorchoice_parent(self._element.accent6)
+
+    @property
+    def hyperlink(self):
+        return ColorFormat.from_colorchoice_parent(self._element.hlink)
+
+    @property
+    def followed_hyperlink(self):
+        return ColorFormat.from_colorchoice_parent(self._element.folHlink)
+
+class FontScheme(ElementProxy):
+    @property
+    def major_font(self):
+        return FontCollection(self._element.majorFont)
+
+    @property
+    def minor_font(self):
+        return FontCollection(self._element.minorFont)
+
+class FormatScheme(ElementProxy):
+    @property
+    def name(self):
+        return self._element.name
+
+    @property
+    def fill_style_list(self):
+        return tuple([FillFormat(self._element.fillStyleLst, _Fill(fill)) for fill in self._element.fillStyleLst])
+        
+    @property
+    def line_style_list(self):
+        return []
+    
+    @property
+    def effect_style_list(self):
+        return []
+
+    @property
+    def background_fill_style_list(self):
+        return tuple([FillFormat(self._element.bgFillStyleLst, _Fill(fill)) for fill in self._element.bgFillStyleLst])
+
+
+class FontCollection(ElementProxy):
+    @property
+    def latin(self): 
+        return TextFont(self.element.latin)
+
+    @property
+    def east_asian(self): 
+        return TextFont(self.element.ea)
+
+    @property
+    def complex_script(self): 
+        return TextFont(self.element.cs)

--- a/pptx/theme.py
+++ b/pptx/theme.py
@@ -60,7 +60,7 @@ class ThemeElements(ElementProxy):
     def format_scheme(self):
         """Read only access to theme's format scheme"""
         return FormatScheme(self._element.fmtScheme)
-    
+
 
 class ColorScheme(ElementProxy):
     @property
@@ -115,6 +115,7 @@ class ColorScheme(ElementProxy):
     def followed_hyperlink(self):
         return ColorFormat.from_colorchoice_parent(self._element.folHlink)
 
+
 class FontScheme(ElementProxy):
     @property
     def major_font(self):
@@ -123,6 +124,7 @@ class FontScheme(ElementProxy):
     @property
     def minor_font(self):
         return FontCollection(self._element.minorFont)
+
 
 class FormatScheme(ElementProxy):
     @property

--- a/tests/parts/test_slide.py
+++ b/tests/parts/test_slide.py
@@ -28,8 +28,10 @@ from pptx.parts.slide import (
     SlideLayoutPart,
     SlideMasterPart,
     SlidePart,
+    ThemePart,
 )
 from pptx.slide import NotesMaster, NotesSlide, Slide, SlideLayout, SlideMaster
+from pptx.theme import Theme
 
 from ..unitutil.cxml import element
 from ..unitutil.file import absjoin, test_file_dir
@@ -760,6 +762,12 @@ class DescribeSlideMasterPart(object):
         getitem_.assert_called_once_with(rId)
         assert slide_layout is slide_layout_
 
+    def it_provides_access_to_its_related_theme(self, theme_fixture):
+        slide_master_part, part_related_by_, theme_ = theme_fixture
+        theme = slide_master_part.related_theme()
+        part_related_by_.assert_called_once_with(slide_master_part, RT.THEME)
+        assert theme is theme_
+
     # fixtures -------------------------------------------------------
 
     @pytest.fixture
@@ -776,6 +784,13 @@ class DescribeSlideMasterPart(object):
         getitem_.return_value.slide_layout = slide_layout_
         return slide_master_part, rId, getitem_, slide_layout_
 
+    @pytest.fixture
+    def theme_fixture(self, part_related_by_, theme_, theme_part_):
+        slide_master_part = SlideMasterPart(None, None, None, None)
+        part_related_by_.return_value = theme_part_
+        theme_part_.theme = theme_
+        return slide_master_part, part_related_by_, theme_
+
     # fixture components ---------------------------------------------
 
     @pytest.fixture
@@ -787,6 +802,10 @@ class DescribeSlideMasterPart(object):
         return instance_mock(request, SlideLayout)
 
     @pytest.fixture
+    def theme_(self, request):
+        return instance_mock(request, Theme)
+
+    @pytest.fixture
     def SlideMaster_(self, request, slide_master_):
         return class_mock(
             request, "pptx.parts.slide.SlideMaster", return_value=slide_master_
@@ -795,3 +814,50 @@ class DescribeSlideMasterPart(object):
     @pytest.fixture
     def slide_master_(self, request):
         return instance_mock(request, SlideMaster)
+
+    @pytest.fixture
+    def theme_part_(self, request):
+        return instance_mock(request, ThemePart)
+    
+    @pytest.fixture
+    def part_related_by_(self, request):
+        return method_mock(request, SlideMasterPart, "part_related_by", autospec=True)
+
+
+class DescribeThemePart(object):
+    def it_knows_its_name(self, name_fixture):
+        theme, expected_value = name_fixture
+        assert theme.name == expected_value
+
+    def it_provides_access_to_its_theme(self, theme_fixture):
+        theme_part, Theme_, sldTheme, theme_ = theme_fixture
+        theme = theme_part.theme
+        Theme_.assert_called_once_with(sldTheme)
+        assert theme is theme_
+
+
+    # fixtures -------------------------------------------------------
+
+    @pytest.fixture
+    def theme_fixture(self, Theme_, theme_):
+        sldTheme = element("a:theme")
+        theme_part = ThemePart(None, None, sldTheme)
+        return theme_part, Theme_, sldTheme, theme_
+
+    @pytest.fixture
+    def name_fixture(self):
+        theme_cxml, expected_value = "a:theme{name=Foobar}", "Foobar"
+        theme = element(theme_cxml)
+        theme = Theme(theme)
+        return theme, expected_value
+
+
+    # fixture components ---------------------------------------------
+
+    @pytest.fixture
+    def theme_(self, request):
+        return instance_mock(request, Theme)
+
+    @pytest.fixture
+    def Theme_(self, request, theme_):
+        return class_mock( request, "pptx.parts.slide.Theme", return_value=theme_)

--- a/tests/test_slide.py
+++ b/tests/test_slide.py
@@ -13,6 +13,7 @@ from pptx.parts.presentation import PresentationPart
 from pptx.parts.slide import SlideLayoutPart, SlideMasterPart, SlidePart
 from pptx.presentation import Presentation
 from pptx.shapes.base import BaseShape
+from pptx.theme import Theme
 from pptx.shapes.placeholder import LayoutPlaceholder, NotesSlidePlaceholder
 from pptx.shapes.shapetree import (
     LayoutPlaceholders,
@@ -953,6 +954,14 @@ class DescribeSlideMaster(object):
         SlideLayouts_.assert_called_once_with(sldLayoutIdLst, slide_master)
         assert slide_layouts is slide_layouts_
 
+    def it_provides_access_to_its_theme(self, theme_, part_prop_):
+        part_prop_.return_value.related_theme = theme_
+        slide_master = SlideMaster(None, None)
+
+        theme = slide_master.theme
+
+        assert theme is theme_
+    
     # fixtures -------------------------------------------------------
 
     @pytest.fixture
@@ -977,6 +986,20 @@ class DescribeSlideMaster(object):
     @pytest.fixture
     def slide_layouts_(self, request):
         return instance_mock(request, SlideLayouts)
+
+    @pytest.fixture
+    def part_prop_(self, request, slide_master_part_):
+        return property_mock(
+            request, SlideMaster, "part", return_value=slide_master_part_
+        )
+
+    @pytest.fixture
+    def slide_master_part_(self, request):
+        return instance_mock(request, SlideMasterPart)
+
+    @pytest.fixture
+    def theme_(self, request):
+        return instance_mock(request, Theme)
 
 
 class DescribeSlideMasters(object):

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -1,0 +1,226 @@
+# encoding: utf-8
+
+"""
+Test suite for pptx.theme module
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import pytest
+
+from pptx.theme import (
+    Theme,
+    ThemeElements,
+    ColorScheme, 
+    FontScheme,
+    FormatScheme,
+    FontCollection,
+)
+from pptx.dml.color import ColorFormat
+from pptx.dml.fill import FillFormat
+from pptx.dml.line import LineStyle
+from pptx.text.text import TextFont
+
+from .unitutil.cxml import element
+
+
+
+class DescribeTheme:
+    def it_knows_its_name(self, name_fixture):
+        theme, expected_value = name_fixture
+        assert theme.name == expected_value
+
+    def it_gives_access_to_its_theme_elements(self, theme):
+        assert isinstance(theme.theme_elements, ThemeElements)
+
+    def it_gives_access_to_color_scheme(self, theme):
+        assert isinstance(theme.color_scheme, ColorScheme)
+
+    def it_gives_access_to_font_scheme(self, theme):
+        assert isinstance(theme.font_scheme, FontScheme)
+
+    def it_gives_Access_to_format_scheme(self, theme):
+        assert isinstance(theme.format_scheme, FormatScheme)
+
+    # fixtures ---------------------------------------------
+
+    @pytest.fixture(
+        params=[
+            ("a:theme", ""),
+            ("a:theme{name=Foobar}", "Foobar")
+        ]
+    )
+    def name_fixture(self, request):
+        theme_cxml, expected_value = request.param
+        theme = Theme(element(theme_cxml))
+        return theme, expected_value
+
+
+    # fixture components ---------------------------------------------
+
+    @pytest.fixture
+    def theme(self):
+        return Theme(element("a:theme/a:themeElements/(a:clrScheme,a:fontScheme,a:fmtScheme)"))
+
+class DescribeThemeElements:
+    def it_gives_access_to_color_scheme(self, theme_elements):
+        assert isinstance(theme_elements.color_scheme, ColorScheme)
+
+    def it_gives_access_to_font_scheme(self, theme_elements):
+        assert isinstance(theme_elements.font_scheme, FontScheme)
+
+    def it_gives_Access_to_format_scheme(self, theme_elements):
+        assert isinstance(theme_elements.format_scheme, FormatScheme)
+
+    # fixtures ---------------------------------------------
+
+    # fixture components ---------------------------------------------
+
+    @pytest.fixture
+    def theme_elements(self):
+        return ThemeElements(element("a:themeElements/(a:clrScheme,a:fontScheme,a:fmtScheme)"))
+
+class DescribeColorScheme:
+    def it_knows_its_name(self, name_fixture):
+        color_scheme, expected_value = name_fixture
+        assert color_scheme.name == expected_value
+        
+    def it_gives_access_to_dk1_color(self, color_scheme):
+        assert isinstance(color_scheme.dk1, ColorFormat)
+
+    def it_gives_access_to_dk2_color(self, color_scheme):
+        assert isinstance(color_scheme.dk2, ColorFormat)
+
+    def it_gives_access_to_lt1_color(self, color_scheme):
+        assert isinstance(color_scheme.lt1, ColorFormat)
+
+    def it_gives_access_to_lt2_color(self, color_scheme):
+        assert isinstance(color_scheme.lt2, ColorFormat)
+
+    def it_gives_access_to_accent1_color(self, color_scheme):
+        assert isinstance(color_scheme.accent1, ColorFormat)
+
+    def it_gives_access_to_accent2_color(self, color_scheme):
+        assert isinstance(color_scheme.accent2, ColorFormat)
+
+    def it_gives_access_to_accent3_color(self, color_scheme):
+        assert isinstance(color_scheme.accent3, ColorFormat)
+
+    def it_gives_access_to_accent4_color(self, color_scheme):
+        assert isinstance(color_scheme.accent4, ColorFormat)
+
+    def it_gives_access_to_accent5_color(self, color_scheme):
+        assert isinstance(color_scheme.accent5, ColorFormat)
+
+    def it_gives_access_to_accent6_color(self, color_scheme):
+        assert isinstance(color_scheme.accent6, ColorFormat)
+
+    def it_gives_access_to_hyperlink_color(self, color_scheme):
+        assert isinstance(color_scheme.hyperlink, ColorFormat)
+
+    def it_gives_access_to_followed_hyperlink_color(self, color_scheme):
+        assert isinstance(color_scheme.followed_hyperlink, ColorFormat)
+
+
+    # fixtures ---------------------------------------------
+    @pytest.fixture(
+        params=[
+            ("a:clrScheme{name=Foobar}", "Foobar")
+        ]
+    )
+    def name_fixture(self, request):
+        clr_scheme_cxml, expected_value = request.param
+        color_scheme = ColorScheme(element(clr_scheme_cxml))
+        return color_scheme, expected_value
+
+    # fixture components ---------------------------------------------
+    
+    @pytest.fixture
+    def color_scheme(self):
+        return ColorScheme(element("a:clrScheme/(a:dk1,a:lt1,a:dk2,a:lt2,a:accent1,a:accent2,a:accent3,a:accent4,a:accent5,a:accent6,a:hlink,a:folHlink)"))
+
+class DescribeFontScheme:
+    def it_gives_access_to_its_major_font(self, font_scheme):
+        assert isinstance(font_scheme.major_font, FontCollection)
+
+    def it_gives_access_to_its_minor_font(self, font_scheme):
+        assert isinstance(font_scheme.minor_font, FontCollection)
+
+    # fixtures ---------------------------------------------
+
+    # fixture components ---------------------------------------------
+
+    @pytest.fixture
+    def font_scheme(self):
+        return FontScheme(element("a:fontScheme/(a:majorFont,a:minorFont)"))
+
+class DescribeFormatScheme:
+    def it_knows_its_name(self, name_fixture):
+        format_scheme, expected_value = name_fixture
+        assert format_scheme.name == expected_value
+
+    def it_knows_its_fill_style_list(self, format_scheme):
+        fill_list = format_scheme.fill_style_list
+        assert isinstance(fill_list, tuple)
+        for fill in fill_list:
+            assert isinstance(fill, FillFormat)
+        
+
+    def it_knows_its_line_style_list(self, format_scheme):
+        line_style_list = format_scheme.line_style_list
+        assert isinstance(line_style_list, tuple)
+        for line in line_style_list:
+            assert isinstance(line, LineStyle)
+        
+
+    def it_knows_its_effect_style_list(self, format_scheme):
+        effect_style_list = format_scheme.effect_style_list
+        assert isinstance(effect_style_list, list)
+        assert effect_style_list == []
+
+    def it_knows_its_background_fill_style_list(self, format_scheme):
+        bg_fill_list = format_scheme.background_fill_style_list
+        assert isinstance(bg_fill_list, tuple)
+        for fill in bg_fill_list:
+            assert isinstance(fill, FillFormat)
+        
+
+    # fixtures ---------------------------------------------
+
+    @pytest.fixture(
+        params=[
+            ("a:fmtScheme", ""),
+            ("a:fmtScheme{name=Foobar}", "Foobar")
+        ]
+    )
+    def name_fixture(self, request):
+        format_scheme_cxml, expected_value = request.param
+        format_scheme = FormatScheme(element(format_scheme_cxml))
+        return format_scheme, expected_value
+
+
+
+
+    # fixture components ---------------------------------------------
+    @pytest.fixture
+    def format_scheme(self, request):
+        return FormatScheme(element("a:fmtScheme/(a:fillStyleLst/(a:noFill,a:solidFill,a:solidFill),a:lnStyleLst/(a:ln,a:ln,a:ln),a:bgFillStyleLst/(a:noFill,a:solidFill,a:solidFill))"))
+
+class DescribeFontCollection:
+    def it_provides_access_to_latin_font(self, font_collection):
+        assert isinstance(font_collection.latin, TextFont)
+
+    def it_provides_access_to_ea_font(self, font_collection):
+        assert isinstance(font_collection.east_asian, TextFont)
+
+    def it_provides_access_to_cs_font(self, font_collection):
+        assert isinstance(font_collection.complex_script, TextFont)
+
+
+    # fixtures ---------------------------------------------
+
+    # fixture components ---------------------------------------------
+
+    @pytest.fixture
+    def font_collection(self):
+        return FontCollection(element("a:majorFont/(a:latin,a:ea,a:cs)"))

--- a/tests/text/test_bullets.py
+++ b/tests/text/test_bullets.py
@@ -1166,7 +1166,7 @@ class DescribeBulletTypefaceSpecific(object):
 
     @pytest.fixture(
         params=[
-            ("a:buFont", None),
+            ("a:buFont", 1),
             ("a:buFont{charset=0}", 0),
         ]
     )
@@ -1178,8 +1178,8 @@ class DescribeBulletTypefaceSpecific(object):
 
     @pytest.fixture(
         params=[
-            ("a:buFont", 1, "a:buFont{charset=1}"),
-            ("a:buFont{charset=0}", 1, "a:buFont{charset=1}"),
+            ("a:buFont", 1, "a:buFont"),
+            ("a:buFont{charset=0}", 1, "a:buFont"),
             ("a:buFont{charset=1}", 0, "a:buFont{charset=0}"),
         ]
     )
@@ -1193,7 +1193,7 @@ class DescribeBulletTypefaceSpecific(object):
 
     @pytest.fixture(
         params=[
-            ("a:buFont", None),
+            ("a:buFont", 0),
             ("a:buFont{pitchFamily=1}", 1),
         ]
     )
@@ -1208,7 +1208,7 @@ class DescribeBulletTypefaceSpecific(object):
         params=[
             ("a:buFont", 1, "a:buFont{pitchFamily=1}"),
             ("a:buFont{pitchFamily=0}", 1, "a:buFont{pitchFamily=1}"),
-            ("a:buFont{pitchFamily=1}", 0, "a:buFont{pitchFamily=0}"),
+            ("a:buFont{pitchFamily=1}", 0, "a:buFont"),
         ]
     )
     def set_pitch_family_fixture(self, request):

--- a/tests/text/test_text.py
+++ b/tests/text/test_text.py
@@ -14,7 +14,7 @@ from pptx.enum.text import MSO_ANCHOR, MSO_AUTO_SIZE, MSO_UNDERLINE, PP_ALIGN
 from pptx.opc.constants import RELATIONSHIP_TYPE as RT
 from pptx.opc.package import Part
 from pptx.shapes.autoshape import Shape
-from pptx.text.text import Font, _Hyperlink, _Paragraph, _Run, TextFrame
+from pptx.text.text import Font, _Hyperlink, _Paragraph, _Run, TextFrame, TextFont
 from pptx.text.bullets import TextBullet, TextBulletColor, TextBulletSize, TextBulletTypeface
 from pptx.util import Inches, Pt
 
@@ -1411,3 +1411,57 @@ class Describe_Run(object):
     @pytest.fixture
     def hlink_(self, request):
         return instance_mock(request, _Hyperlink)
+
+
+class Describe_TextFont(object):
+    def it_knows_its_typeface(self, typeface_get_fixture):
+        text_font, expected_value = typeface_get_fixture
+        assert text_font.typeface == expected_value
+
+    def it_knows_its_panose(self, panose_get_fixture):
+        text_font, expected_value = panose_get_fixture
+        assert text_font.panose == expected_value
+
+    def it_knows_its_pitch_family(self, pitch_get_fixture):
+        text_font, expected_value = pitch_get_fixture
+        assert text_font.pitch_family == expected_value
+
+    def it_knows_its_charset(self, charset_get_fixture):
+        text_font, expected_value = charset_get_fixture
+        assert text_font.charset == expected_value
+
+    # fixtures ---------------------------------------------
+
+
+    @pytest.fixture(
+        params=[("a:latin", None), ("a:latin{typeface=Foobar}", "Foobar")]
+    )
+    def typeface_get_fixture(self, request):
+        latin_cxml, expected_value = request.param
+        text_font = TextFont(element(latin_cxml))
+        return text_font, expected_value
+
+    @pytest.fixture(
+        params=[("a:latin", None), ("a:latin{panose=020F0502020204030204}", "020F0502020204030204")]
+    )
+    def panose_get_fixture(self, request):
+        latin_cxml, expected_value = request.param
+        text_font = TextFont(element(latin_cxml))
+        return text_font, expected_value
+
+    @pytest.fixture(
+        params=[("a:latin", 0), ("a:latin{pitchFamily=1}", 1), ("a:latin{pitchFamily=0}", 0)]
+    )
+    def pitch_get_fixture(self, request):
+        latin_cxml, expected_value = request.param
+        text_font = TextFont(element(latin_cxml))
+        return text_font, expected_value
+
+    @pytest.fixture(
+        params=[("a:latin", 1), ("a:latin{charset=0}", 0), ("a:latin{charset=1}", 1)]
+    )
+    def charset_get_fixture(self, request):
+        latin_cxml, expected_value = request.param
+        text_font = TextFont(element(latin_cxml))
+        return text_font, expected_value
+


### PR DESCRIPTION
This is probably the most complex and extensive addition to the library.  You can think of a theme as an ultimate default set of styles that can be applied to a master slide and all its children.  It includes a set of preset colors, fonts, and other things like default line formatting and style effects.  

For this implementation, I have made this all read only so we are reading values from current themes, not making any changes or updates.  Fortunately, I was able to make use of a lot of existing classes like Fills and Colors but I did have to create a bit of a new one with the LineStyle as LineFormat requires a parent object which we don't have in this instance (it's multiple line elements in a list).  

I am going to go ahead and open this PR for the moment and start to utilize this branch in the SlideBuilder to make sure it works.  Once I confirm it is all working, I'll come back, do a few cleanups, and write a hole bunch of Unit Tests.