### PR TITLE
DB-1097 - Enhanced Slide Master Processing

### DIFF
--- a/pptx/dml/color.py
+++ b/pptx/dml/color.py
@@ -143,6 +143,33 @@ class ColorFormat(object):
             self._color = _SysColor(sysColor)
         self._color.system_color = value
     
+    @property
+    def red(self):
+        """ SCRGB Red Value """
+        return self._color.red
+    
+    @red.setter
+    def red(self, percent):
+        self._color.red = percent
+
+    @property
+    def blue(self):
+        """ SCRGB Blue Value """
+        return self._color.reblued
+    
+    @blue.setter
+    def blue(self, percent):
+        self._color.blue = percent
+
+    @property
+    def green(self):
+        """ SCRGB Green Value """
+        return self._color.green
+    
+    @green.setter
+    def green(self, percent):
+        self._color.green = percent
+
 
 class _Color(object):
     """
@@ -224,6 +251,33 @@ class _Color(object):
         """
         tmpl = "no .preset_color property on color type '%s'"
         raise AttributeError(tmpl % self.__class__.__name__)
+
+    @property
+    def red(self):
+        """
+        Raises TypeError on access unless overridden by subclass.
+        """
+        tmpl = "no .red property on color type '%s'"
+        raise AttributeError(tmpl % self.__class__.__name__)
+
+    @property
+    def green(self):
+        """
+        Raises TypeError on access unless overridden by subclass.
+        """
+        tmpl = "no .green property on color type '%s'"
+        raise AttributeError(tmpl % self.__class__.__name__)
+
+    @property
+    def blue(self):
+        """
+        Raises TypeError on access unless overridden by subclass.
+        """
+        tmpl = "no .blue property on color type '%s'"
+        raise AttributeError(tmpl % self.__class__.__name__)
+
+
+
 
     def _shade(self, value):
         lumMod_val = 1.0 - abs(value)

--- a/pptx/dml/color.py
+++ b/pptx/dml/color.py
@@ -150,6 +150,11 @@ class ColorFormat(object):
     
     @red.setter
     def red(self, percent):
+        # change to scrgb color format if not already
+        if not isinstance(self._color, _ScRgbColor):
+            scrgbClr = self._xFill.get_or_change_to_scrgbClr()
+            self._color = _ScRgbColor(scrgbClr)
+        # call _ScRgbColor instance to do the setting
         self._color.red = percent
 
     @property
@@ -159,6 +164,11 @@ class ColorFormat(object):
     
     @blue.setter
     def blue(self, percent):
+        # change to scrgb color format if not already
+        if not isinstance(self._color, _ScRgbColor):
+            scrgbClr = self._xFill.get_or_change_to_scrgbClr()
+            self._color = _ScRgbColor(scrgbClr)
+        # call _ScRgbColor instance to do the setting
         self._color.blue = percent
 
     @property
@@ -168,6 +178,11 @@ class ColorFormat(object):
     
     @green.setter
     def green(self, percent):
+        # change to scrgb color format if not already
+        if not isinstance(self._color, _ScRgbColor):
+            scrgbClr = self._xFill.get_or_change_to_scrgbClr()
+            self._color = _ScRgbColor(scrgbClr)
+        # call _ScRgbColor instance to do the setting
         self._color.green = percent
 
 
@@ -377,7 +392,7 @@ class _ScRgbColor(_Color):
     
     @red.setter
     def red(self, percent):
-        self._srgbClr.r = percent
+        self._scrgbClr.r = percent
 
     @property
     def green(self):
@@ -385,7 +400,7 @@ class _ScRgbColor(_Color):
     
     @green.setter
     def green(self, percent):
-        self._srgbClr.g = percent
+        self._scrgbClr.g = percent
 
     @property
     def blue(self):
@@ -393,7 +408,7 @@ class _ScRgbColor(_Color):
 
     @blue.setter
     def blue(self, percent):
-        self._srgbClr.b = percent
+        self._scrgbClr.b = percent
 
 class _SRgbColor(_Color):
     def __init__(self, srgbClr):

--- a/pptx/dml/color.py
+++ b/pptx/dml/color.py
@@ -309,10 +309,37 @@ class _SchemeColor(_Color):
 
 
 class _ScRgbColor(_Color):
+    def __init__(self, scrgbClrr):
+        super(_ScRgbColor, self).__init__(scrgbClr)
+        self._scrgbClr = scrgbClrr
+
     @property
     def color_type(self):
         return MSO_COLOR_TYPE.SCRGB
 
+    @property
+    def red(self):
+        return self._scrgbClr.r
+    
+    @red.setter
+    def red(self, percent):
+        self._srgbClr.r = percent
+
+    @property
+    def green(self):
+        return self._scrgbClr.g
+    
+    @green.setter
+    def green(self, percent):
+        self._srgbClr.g = percent
+
+    @property
+    def blue(self):
+        return self_.scrgbClr.b
+
+    @blue.setter
+    def blue(self, percent):
+        self._srgbClr.b = percent
 
 class _SRgbColor(_Color):
     def __init__(self, srgbClr):

--- a/pptx/dml/color.py
+++ b/pptx/dml/color.py
@@ -240,7 +240,7 @@ class _Color(object):
     @property
     def rgb(self):
         """
-        Raises TypeError on access unless overridden by subclass.
+        Raises AttributeError on access unless overridden by subclass.
         """
         tmpl = "no .rgb property on color type '%s'"
         raise AttributeError(tmpl % self.__class__.__name__)
@@ -270,7 +270,7 @@ class _Color(object):
     @property
     def red(self):
         """
-        Raises TypeError on access unless overridden by subclass.
+        Raises AttributeError on access unless overridden by subclass.
         """
         tmpl = "no .red property on color type '%s'"
         raise AttributeError(tmpl % self.__class__.__name__)
@@ -278,7 +278,7 @@ class _Color(object):
     @property
     def green(self):
         """
-        Raises TypeError on access unless overridden by subclass.
+        Raises AttributeError on access unless overridden by subclass.
         """
         tmpl = "no .green property on color type '%s'"
         raise AttributeError(tmpl % self.__class__.__name__)
@@ -286,7 +286,7 @@ class _Color(object):
     @property
     def blue(self):
         """
-        Raises TypeError on access unless overridden by subclass.
+        Raises AttributeError on access unless overridden by subclass.
         """
         tmpl = "no .blue property on color type '%s'"
         raise AttributeError(tmpl % self.__class__.__name__)

--- a/pptx/dml/color.py
+++ b/pptx/dml/color.py
@@ -155,7 +155,7 @@ class ColorFormat(object):
     @property
     def blue(self):
         """ SCRGB Blue Value """
-        return self._color.reblued
+        return self._color.blue
     
     @blue.setter
     def blue(self, percent):
@@ -363,9 +363,9 @@ class _SchemeColor(_Color):
 
 
 class _ScRgbColor(_Color):
-    def __init__(self, scrgbClrr):
+    def __init__(self, scrgbClr):
         super(_ScRgbColor, self).__init__(scrgbClr)
-        self._scrgbClr = scrgbClrr
+        self._scrgbClr = scrgbClr
 
     @property
     def color_type(self):
@@ -389,7 +389,7 @@ class _ScRgbColor(_Color):
 
     @property
     def blue(self):
-        return self_.scrgbClr.b
+        return self._scrgbClr.b
 
     @blue.setter
     def blue(self, percent):

--- a/pptx/dml/fill.py
+++ b/pptx/dml/fill.py
@@ -380,6 +380,11 @@ class _GradientStops(Sequence):
         return len(self._gsLst)
 
 
+    def add_gradient_stop(self):
+        self._gsLst.add_gs()
+        return _GradientStop(self._gsLst[-1])
+
+
 class _GradientStop(ElementProxy):
     """A single gradient stop.
 

--- a/pptx/enum/dml.py
+++ b/pptx/enum/dml.py
@@ -312,6 +312,7 @@ class MSO_THEME_COLOR_INDEX(XmlEnumeration):
         XmlMappedEnumMember("LIGHT_2", 4, "lt2", "Specifies the Light 2 theme color."),
         XmlMappedEnumMember("TEXT_1", 13, "tx1", "Specifies the Text 1 theme color."),
         XmlMappedEnumMember("TEXT_2", 15, "tx2", "Specifies the Text 2 theme color."),
+        XmlMappedEnumMember("PLACEHOLDER", 16, "phClr", "Specifies to use the Style Color."),
         ReturnValueOnlyEnumMember(
             "MIXED",
             -2,

--- a/pptx/oxml/__init__.py
+++ b/pptx/oxml/__init__.py
@@ -417,6 +417,7 @@ from .slide import (  # noqa: E402
     CT_TimeNodeList,
     CT_TLMediaNodeVideo,
     CT_ColorMappingOverride,
+    CT_SlideMasterTextStyles,
     CT_TextListStyle,
 )
 
@@ -434,6 +435,7 @@ register_element_cls("p:sldMaster", CT_SlideMaster)
 register_element_cls("p:timing", CT_SlideTiming)
 register_element_cls("p:video", CT_TLMediaNodeVideo)
 register_element_cls("p:clrMapOvr", CT_ColorMappingOverride)
+register_element_cls("p:txStyles", CT_SlideMasterTextStyles)
 register_element_cls("p:titleStyle", CT_TextListStyle)
 register_element_cls("p:bodyStyle", CT_TextListStyle)
 register_element_cls("p:otherStyle", CT_TextListStyle)

--- a/pptx/oxml/__init__.py
+++ b/pptx/oxml/__init__.py
@@ -292,7 +292,6 @@ register_element_cls("p:sldMasterId", CT_SlideMasterIdListEntry)
 register_element_cls("p:sldMasterIdLst", CT_SlideMasterIdList)
 register_element_cls("p:sldSz", CT_SlideSize)
 
-
 from .shapes.autoshape import (  # noqa: E402
     CT_AdjPoint2D,
     CT_CustomGeometry2D,
@@ -418,6 +417,7 @@ from .slide import (  # noqa: E402
     CT_TimeNodeList,
     CT_TLMediaNodeVideo,
     CT_ColorMappingOverride,
+    CT_TextListStyle,
 )
 
 register_element_cls("p:bg", CT_Background)
@@ -434,6 +434,9 @@ register_element_cls("p:sldMaster", CT_SlideMaster)
 register_element_cls("p:timing", CT_SlideTiming)
 register_element_cls("p:video", CT_TLMediaNodeVideo)
 register_element_cls("p:clrMapOvr", CT_ColorMappingOverride)
+register_element_cls("p:titleStyle", CT_TextListStyle)
+register_element_cls("p:bodyStyle", CT_TextListStyle)
+register_element_cls("p:otherStyle", CT_TextListStyle)
 
 
 from .table import (  # noqa: E402
@@ -523,6 +526,16 @@ register_element_cls("p:txBody", CT_TextBody)
 register_element_cls("a:ea", CT_TextFont)
 register_element_cls("a:cs", CT_TextFont)
 register_element_cls("a:font", CT_SupplementalFont)
+register_element_cls("a:defPPr", CT_TextParagraphProperties)
+register_element_cls("a:lvl1pPr", CT_TextParagraphProperties)
+register_element_cls("a:lvl2pPr", CT_TextParagraphProperties)
+register_element_cls("a:lvl3pPr", CT_TextParagraphProperties)
+register_element_cls("a:lvl4pPr", CT_TextParagraphProperties)
+register_element_cls("a:lvl5pPr", CT_TextParagraphProperties)
+register_element_cls("a:lvl6pPr", CT_TextParagraphProperties)
+register_element_cls("a:lvl7pPr", CT_TextParagraphProperties)
+register_element_cls("a:lvl8pPr", CT_TextParagraphProperties)
+register_element_cls("a:lvl9pPr", CT_TextParagraphProperties)
 
 
 

--- a/pptx/oxml/__init__.py
+++ b/pptx/oxml/__init__.py
@@ -417,6 +417,7 @@ from .slide import (  # noqa: E402
     CT_SlideTiming,
     CT_TimeNodeList,
     CT_TLMediaNodeVideo,
+    CT_ColorMappingOverride,
 )
 
 register_element_cls("p:bg", CT_Background)
@@ -432,6 +433,7 @@ register_element_cls("p:sldLayoutIdLst", CT_SlideLayoutIdList)
 register_element_cls("p:sldMaster", CT_SlideMaster)
 register_element_cls("p:timing", CT_SlideTiming)
 register_element_cls("p:video", CT_TLMediaNodeVideo)
+register_element_cls("p:clrMapOvr", CT_ColorMappingOverride)
 
 
 from .table import (  # noqa: E402
@@ -531,8 +533,10 @@ from .theme import (
     CT_FontScheme,
     CT_StyleMatrix,
     CT_ColorMapping,
+    CT_EmptyElement,
 )
 register_element_cls("p:clrMap", CT_ColorMapping)
+register_element_cls("a:overrideClrMapping", CT_ColorMapping)
 register_element_cls("a:theme", CT_OfficeStyleSheet)
 register_element_cls("a:themeElements", CT_BaseStyles)
 register_element_cls("a:clrScheme", CT_ColorScheme)
@@ -553,3 +557,4 @@ register_element_cls("a:hlink", CT_Color)
 register_element_cls("a:folHlink", CT_Color)
 register_element_cls("a:majorFont", CT_FontCollection)
 register_element_cls("a:minorFont", CT_FontCollection)
+register_element_cls("a:masterClrMapping", CT_EmptyElement)

--- a/pptx/oxml/__init__.py
+++ b/pptx/oxml/__init__.py
@@ -439,6 +439,7 @@ register_element_cls("p:txStyles", CT_SlideMasterTextStyles)
 register_element_cls("p:titleStyle", CT_TextListStyle)
 register_element_cls("p:bodyStyle", CT_TextListStyle)
 register_element_cls("p:otherStyle", CT_TextListStyle)
+register_element_cls("a:lstStyle", CT_TextListStyle)
 
 
 from .table import (  # noqa: E402

--- a/pptx/oxml/__init__.py
+++ b/pptx/oxml/__init__.py
@@ -574,3 +574,9 @@ register_element_cls("a:folHlink", CT_Color)
 register_element_cls("a:majorFont", CT_FontCollection)
 register_element_cls("a:minorFont", CT_FontCollection)
 register_element_cls("a:masterClrMapping", CT_EmptyElement)
+
+
+from .media import (
+    CT_OfficeArtExtensionList,  # noqa: E402
+)
+register_element_cls("a:extList", CT_OfficeArtExtensionList)

--- a/pptx/oxml/__init__.py
+++ b/pptx/oxml/__init__.py
@@ -579,4 +579,4 @@ register_element_cls("a:masterClrMapping", CT_EmptyElement)
 from .media import (
     CT_OfficeArtExtensionList,  # noqa: E402
 )
-register_element_cls("a:extList", CT_OfficeArtExtensionList)
+register_element_cls("a:extLst", CT_OfficeArtExtensionList)

--- a/pptx/oxml/__init__.py
+++ b/pptx/oxml/__init__.py
@@ -530,8 +530,9 @@ from .theme import (
     CT_ColorScheme,
     CT_FontScheme,
     CT_StyleMatrix,
+    CT_ColorMapping,
 )
-
+register_element_cls("p:clrMap", CT_ColorMapping)
 register_element_cls("a:theme", CT_OfficeStyleSheet)
 register_element_cls("a:themeElements", CT_BaseStyles)
 register_element_cls("a:clrScheme", CT_ColorScheme)

--- a/pptx/oxml/__init__.py
+++ b/pptx/oxml/__init__.py
@@ -52,10 +52,11 @@ def register_element_cls(nsptagname, cls):
     namespace[nsptag.local_part] = cls
 
 
-from .action import CT_Hyperlink  # noqa: E402
+from .action import CT_Hyperlink, HyperlinkColorExtension  # noqa: E402
 
 register_element_cls("a:hlinkClick", CT_Hyperlink)
 register_element_cls("a:hlinkHover", CT_Hyperlink)
+register_element_cls("ahyp:hlinkClr", HyperlinkColorExtension)
 
 
 from .chart.axis import (  # noqa: E402

--- a/pptx/oxml/action.py
+++ b/pptx/oxml/action.py
@@ -7,7 +7,7 @@ lxml custom element classes for text-related XML elements.
 from __future__ import absolute_import
 
 from .simpletypes import XsdString
-from .xmlchemy import BaseOxmlElement, OptionalAttribute
+from .xmlchemy import BaseOxmlElement, ZeroOrOne, OptionalAttribute
 
 
 class CT_Hyperlink(BaseOxmlElement):
@@ -17,6 +17,7 @@ class CT_Hyperlink(BaseOxmlElement):
 
     rId = OptionalAttribute("r:id", XsdString)
     action = OptionalAttribute("action", XsdString)
+    extLst = ZeroOrOne("a:extLst", successors=())
 
     @property
     def action_fields(self):

--- a/pptx/oxml/action.py
+++ b/pptx/oxml/action.py
@@ -7,7 +7,7 @@ lxml custom element classes for text-related XML elements.
 from __future__ import absolute_import
 
 from .simpletypes import XsdString
-from .xmlchemy import BaseOxmlElement, ZeroOrOne, OptionalAttribute
+from .xmlchemy import BaseOxmlElement, ZeroOrOne, OptionalAttribute, RequiredAttribute
 
 
 class CT_Hyperlink(BaseOxmlElement):
@@ -58,3 +58,13 @@ class CT_Hyperlink(BaseOxmlElement):
         host = protocol_and_host[11:]
 
         return host
+
+
+
+class HyperlinkColorExtension(BaseOxmlElement):
+    """
+    Custom class to handle `ahyp:hlinkClr` child of `a:ext`
+    that is used for coloring individual hyperlinks
+    """
+    val = RequiredAttribute("val", XsdString)
+    

--- a/pptx/oxml/dml/color.py
+++ b/pptx/oxml/dml/color.py
@@ -100,6 +100,9 @@ class CT_ScRgbColor(_BaseColorElement):
     """
     Custom element class for <a:scrgbClr> element.
     """
+    r = RequiredAttribute("r", ST_Percentage)
+    g = RequiredAttribute("g", ST_Percentage)
+    b = RequiredAttribute("b", ST_Percentage)
 
 
 class CT_SRgbColor(_BaseColorElement):

--- a/pptx/oxml/dml/fill.py
+++ b/pptx/oxml/dml/fill.py
@@ -14,6 +14,7 @@ from pptx.oxml.simpletypes import (
     ST_PositiveFixedAngle,
     ST_PositiveFixedPercentage,
     ST_RelationshipId,
+    XsdBoolean,
 )
 from pptx.oxml.xmlchemy import (
     BaseOxmlElement,
@@ -60,6 +61,8 @@ class CT_GradientFillProperties(BaseOxmlElement):
     lin = ZeroOrOne("a:lin", successors=_tag_seq[2:])
     path = ZeroOrOne("a:path", successors=_tag_seq[3:])
     del _tag_seq
+
+    rotWithShape = OptionalAttribute("rotWithShape", XsdBoolean)
 
     @classmethod
     def new_gradFill(cls):

--- a/pptx/oxml/media.py
+++ b/pptx/oxml/media.py
@@ -1,0 +1,22 @@
+# encoding: utf-8
+
+"""
+lxml custom element classes for ext-related XML elements.
+"""
+
+from __future__ import absolute_import
+
+from .xmlchemy import ZeroOrMore
+
+
+class CT_OfficeArtExtensionList(BaseOxmlElement):
+    """
+    Custom element class for <a:CT_OfficeArtExtensionList> elements.
+    """
+    ext = ZeroOrMore("a:ext")
+    
+    def add_extension(self, uri):
+        ext = self._add_ext()
+        ext.uri = uri
+        hyperlinkColor = ext.get_or_add_hyperlinkColor()
+        return ext

--- a/pptx/oxml/media.py
+++ b/pptx/oxml/media.py
@@ -6,7 +6,7 @@ lxml custom element classes for ext-related XML elements.
 
 from __future__ import absolute_import
 
-from .xmlchemy import ZeroOrMore
+from .xmlchemy import ZeroOrMore, BaseOxmlElement
 
 
 class CT_OfficeArtExtensionList(BaseOxmlElement):

--- a/pptx/oxml/media.py
+++ b/pptx/oxml/media.py
@@ -15,8 +15,6 @@ class CT_OfficeArtExtensionList(BaseOxmlElement):
     """
     ext = ZeroOrMore("a:ext")
     
-    def add_extension(self, uri):
+    def add_extension(self):
         ext = self._add_ext()
-        ext.uri = uri
-        hyperlinkColor = ext.get_or_add_hyperlinkColor()
         return ext

--- a/pptx/oxml/ns.py
+++ b/pptx/oxml/ns.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import
 #: namespaces.
 _nsmap = {
     "a": ("http://schemas.openxmlformats.org/drawingml/2006/main"),
+    "ahyp": ("http://schemas.microsoft.com/office/drawing/2018/hyperlinkcolor"),
     "c": ("http://schemas.openxmlformats.org/drawingml/2006/chart"),
     "cp": (
         "http://schemas.openxmlformats.org/package/2006/metadata/core-pro" "perties"

--- a/pptx/oxml/shapes/shared.py
+++ b/pptx/oxml/shapes/shared.py
@@ -30,6 +30,7 @@ from pptx.oxml.xmlchemy import (
     ZeroOrOne,
     ZeroOrOneChoice,
     OneAndOnlyOne,
+    ZeroOrMore,
 )
 from pptx.util import Emu
 
@@ -356,10 +357,17 @@ class CT_Point2D(BaseOxmlElement):
 class CT_PositiveSize2D(BaseOxmlElement):
     """
     Custom element class for <a:ext> element.
+
+    NOTE: this is a composite including `CT_OfficeArtExtension`, which appears
+    with the `a:extLst` tag in many different elements.  It currently only implements
+    the inclusion of the optional URI tag and a single `ext` element for hyperlink color.
     """
+
+    hyperlinkColor = ZeroOrOne("ahyp:hlinkClr")
 
     cx = RequiredAttribute("cx", ST_PositiveCoordinate)
     cy = RequiredAttribute("cy", ST_PositiveCoordinate)
+    uri = OptionalAttribute("uri", XsdString)
 
 
 class CT_ShapeProperties(BaseOxmlElement):

--- a/pptx/oxml/shapes/shared.py
+++ b/pptx/oxml/shapes/shared.py
@@ -329,7 +329,7 @@ class CT_NonVisualDrawingProps(BaseOxmlElement):
     hlinkHover = ZeroOrOne("a:hlinkHover", successors=_tag_seq[2:])
     id = RequiredAttribute("id", ST_DrawingElementId)
     name = RequiredAttribute("name", XsdString)
-    hidden = OptionalAttribute("hidden", XsdBoolean, default="false")
+    hidden = OptionalAttribute("hidden", XsdBoolean, default=False)
     del _tag_seq
 
 

--- a/pptx/oxml/shapes/shared.py
+++ b/pptx/oxml/shapes/shared.py
@@ -171,6 +171,13 @@ class BaseShapeElement(BaseOxmlElement):
         return self._nvXxPr.cNvPr.name
 
     @property
+    def hidden(self):
+        """
+        Hidden Status
+        """
+        return self._nvXxPr.cNvPr.hidden
+
+    @property
     def txBody(self):
         """
         Child ``<p:txBody>`` element, None if not present
@@ -322,6 +329,7 @@ class CT_NonVisualDrawingProps(BaseOxmlElement):
     hlinkHover = ZeroOrOne("a:hlinkHover", successors=_tag_seq[2:])
     id = RequiredAttribute("id", ST_DrawingElementId)
     name = RequiredAttribute("name", XsdString)
+    hidden = OptionalAttribute("hidden", XsdBoolean, default="false")
     del _tag_seq
 
 

--- a/pptx/oxml/simpletypes.py
+++ b/pptx/oxml/simpletypes.py
@@ -998,3 +998,24 @@ class ST_PresetColorVal(XsdTokenEnumeration):
         "yellowGreen"        
     )
     _members = color_values
+
+class ST_ColorSchemeIndex(XsdTokenEnumeration):
+    """
+    Valid vlaues for scheme color attribute
+    """
+    color_values = (
+        "dk1",
+        "lt1",
+        "dk2",
+        "lt2",
+        "accent1",
+        "accent2",
+        "accent3",
+        "accent4",
+        "accent5",
+        "accent6",
+        "hlink",
+        "folHlink",
+    )
+    _members = color_values
+

--- a/pptx/oxml/slide.py
+++ b/pptx/oxml/slide.py
@@ -324,6 +324,7 @@ class CT_SlideMaster(_BaseSlideElement):
     cSld = OneAndOnlyOne("p:cSld")
     clrMap = OneAndOnlyOne("p:clrMap")
     sldLayoutIdLst = ZeroOrOne("p:sldLayoutIdLst", successors=_tag_seq[3:])
+    txStyles = ZeroOrOne("p:txStyles", successors=_tag_seq[7:])
     del _tag_seq
 
 

--- a/pptx/oxml/slide.py
+++ b/pptx/oxml/slide.py
@@ -301,6 +301,7 @@ class CT_SlideMaster(_BaseSlideElement):
         "p:extLst",
     )
     cSld = OneAndOnlyOne("p:cSld")
+    clrMap = OneAndOnlyOne("p:clrMap")
     sldLayoutIdLst = ZeroOrOne("p:sldLayoutIdLst", successors=_tag_seq[3:])
     del _tag_seq
 

--- a/pptx/oxml/slide.py
+++ b/pptx/oxml/slide.py
@@ -257,7 +257,9 @@ class CT_SlideLayout(_BaseSlideElement):
     """
 
     _tag_seq = ("p:cSld", "p:clrMapOvr", "p:transition", "p:timing", "p:hf", "p:extLst")
-    cSld = OneAndOnlyOne("p:cSld")
+    cSld = OneAndOnlyOne("p:cSld") 
+    clrMapOvr = ZeroOrOne("p:clrMapOvr", successors=_tag_seq[2:])
+
     del _tag_seq
     
     @property
@@ -283,6 +285,25 @@ class CT_SlideLayoutIdListEntry(BaseOxmlElement):
     """
 
     rId = RequiredAttribute("r:id", XsdString)
+
+class CT_ColorMappingOverride(BaseOxmlElement):
+    """
+    ``<p:clrMapOvr>`` element containing an optional overwritten color map
+    """
+    eg_colorMappingOverride = ZeroOrOneChoice(
+        (
+            Choice("a:masterClrMapping"),
+            Choice("a:overrideClrMapping")
+        )
+    )
+
+    @property
+    def color_map_override(self):
+        if self.overrideClrMapping is not None:
+            return self.overrideClrMapping
+        else:
+            return None
+
 
 
 class CT_SlideMaster(_BaseSlideElement):

--- a/pptx/oxml/slide.py
+++ b/pptx/oxml/slide.py
@@ -371,3 +371,46 @@ class CT_TLMediaNodeVideo(BaseOxmlElement):
     _tag_seq = ("p:cMediaNode",)
     cMediaNode = OneAndOnlyOne("p:cMediaNode")
     del _tag_seq
+
+class CT_SlideMasterTextStyles(BaseOxmlElement):
+    """ `p:txStyles` element """
+
+    _tag_seq = (
+        "p:titleStyle",
+        "p:bodyStyle",
+        "p:otherStyle",
+        "p:extLst"
+    )
+    titleStyle = ZeroOrOne("p:titleStyle", successors=_tag_seq[1:])
+    bodyStyle = ZeroOrOne("p:bodyStyle", successors=_tag_seq[2:])
+    otherStyle = ZeroOrOne("p:otherStyle", successors=_tag_seq[3:])
+    del _tag_seq
+
+
+
+class CT_TextListStyle(BaseOxmlElement):
+    """ a element consisting of a list of paragraph styles used as templates """
+    _tag_seq = (
+        "a:defPPr",
+        "a:lvl1pPr",
+        "a:lvl2pPr",
+        "a:lvl3pPr",
+        "a:lvl4pPr",
+        "a:lvl5pPr",
+        "a:lvl6pPr",
+        "a:lvl7pPr",
+        "a:lvl8pPr",
+        "a:lvl9pPr",
+        "a:extLst",
+    )
+    defPPr = ZeroOrOne("a:defPPr", successors=_tag_seq[1:])
+    lvl1pPr = ZeroOrOne("a:lvl1pPr", successors=_tag_seq[2:])
+    lvl2pPr = ZeroOrOne("a:lvl2pPr", successors=_tag_seq[3:])
+    lvl3pPr = ZeroOrOne("a:lvl3pPr", successors=_tag_seq[4:])
+    lvl4pPr = ZeroOrOne("a:lvl4pPr", successors=_tag_seq[5:])
+    lvl5pPr = ZeroOrOne("a:lvl5pPr", successors=_tag_seq[6:])
+    lvl6pPr = ZeroOrOne("a:lvl6pPr", successors=_tag_seq[7:])
+    lvl7pPr = ZeroOrOne("a:lvl7pPr", successors=_tag_seq[8:])
+    lvl8pPr = ZeroOrOne("a:lvl8pPr", successors=_tag_seq[9:])
+    lvl9pPr = ZeroOrOne("a:lvl9pPr", successors=_tag_seq[10:])
+    del _tag_seq

--- a/pptx/oxml/text.py
+++ b/pptx/oxml/text.py
@@ -312,7 +312,7 @@ class CT_TextCharacterProperties(BaseOxmlElement):
     hlinkClick = ZeroOrOne(
         "a:hlinkClick", successors=("a:hlinkMouseOver", "a:rtl", "a:extLst")
     )
-
+    extList = ZeroOrOne("a:extList", successors=())
     lang = OptionalAttribute("lang", MSO_LANGUAGE_ID)
     sz = OptionalAttribute("sz", ST_TextFontSize)
     b = OptionalAttribute("b", XsdBoolean)
@@ -320,7 +320,7 @@ class CT_TextCharacterProperties(BaseOxmlElement):
     u = OptionalAttribute("u", MSO_TEXT_UNDERLINE_TYPE)
     baseline = OptionalAttribute("baseline", ST_Percentage)
     strike = OptionalAttribute("strike", ST_TextStrikeType)
-    
+
     def _new_gradFill(self):
         return CT_GradientFillProperties.new_gradFill()
 

--- a/pptx/oxml/text.py
+++ b/pptx/oxml/text.py
@@ -92,6 +92,7 @@ class CT_TextBody(BaseOxmlElement):
     """
 
     bodyPr = OneAndOnlyOne("a:bodyPr")
+    lstStyle = ZeroOrOne("a:lstStyle", successors=("p"))
     p = OneOrMore("a:p")
 
     def clear_content(self):

--- a/pptx/oxml/text.py
+++ b/pptx/oxml/text.py
@@ -312,7 +312,6 @@ class CT_TextCharacterProperties(BaseOxmlElement):
     hlinkClick = ZeroOrOne(
         "a:hlinkClick", successors=("a:hlinkMouseOver", "a:rtl", "a:extLst")
     )
-    extList = ZeroOrOne("a:extList", successors=())
     lang = OptionalAttribute("lang", MSO_LANGUAGE_ID)
     sz = OptionalAttribute("sz", ST_TextFontSize)
     b = OptionalAttribute("b", XsdBoolean)

--- a/pptx/oxml/theme.py
+++ b/pptx/oxml/theme.py
@@ -18,7 +18,8 @@ from .xmlchemy import (
 )
 
 from pptx.oxml.simpletypes import (
-    XsdString
+    XsdString,
+    ST_ColorSchemeIndex
 )
 class CT_OfficeStyleSheet(BaseOxmlElement):
     """
@@ -156,3 +157,19 @@ class CT_BackgroundFillStyleList(BaseOxmlElement):
             Choice("a:grpFill"),
         )
     )
+
+
+class CT_ColorMapping(BaseOxmlElement):
+    bg1 = RequiredAttribute("bg1", ST_ColorSchemeIndex)
+    tx1 = RequiredAttribute("tx1", ST_ColorSchemeIndex)
+    bg2 = RequiredAttribute("bg2", ST_ColorSchemeIndex)
+    tx2 = RequiredAttribute("tx2", ST_ColorSchemeIndex)
+    accent1 = RequiredAttribute("accent1", ST_ColorSchemeIndex)
+    accent2 = RequiredAttribute("accent2", ST_ColorSchemeIndex)
+    accent3 = RequiredAttribute("accent3", ST_ColorSchemeIndex)
+    accent4 = RequiredAttribute("accent4", ST_ColorSchemeIndex)
+    accent5 = RequiredAttribute("accent5", ST_ColorSchemeIndex)
+    accent6 = RequiredAttribute("accent6", ST_ColorSchemeIndex)
+    hlink = RequiredAttribute("hlink", ST_ColorSchemeIndex)
+    folHlink = RequiredAttribute("folHlink", ST_ColorSchemeIndex)
+    

--- a/pptx/oxml/theme.py
+++ b/pptx/oxml/theme.py
@@ -173,3 +173,6 @@ class CT_ColorMapping(BaseOxmlElement):
     hlink = RequiredAttribute("hlink", ST_ColorSchemeIndex)
     folHlink = RequiredAttribute("folHlink", ST_ColorSchemeIndex)
     
+class CT_EmptyElement(BaseOxmlElement):
+    """ An Empty Element with no attributes or properties """
+    pass

--- a/pptx/parts/slide.py
+++ b/pptx/parts/slide.py
@@ -252,6 +252,16 @@ class SlidePart(BaseSlidePart):
         self.relate_to(notes_slide_part, RT.NOTES_SLIDE)
         return notes_slide_part
 
+    @property
+    def color_map_override(self):
+        """
+        Color Mapping object to override those in the slide master
+        """
+        override = self._element.clrMapOvr.color_map_override
+        if override is not None:
+            return ColorMap(override)
+        return None
+
 
 class SlideLayoutPart(BaseSlidePart):
     """
@@ -273,6 +283,15 @@ class SlideLayoutPart(BaseSlidePart):
         """
         return self.part_related_by(RT.SLIDE_MASTER).slide_master
 
+    @property
+    def color_map_override(self):
+        """
+        Color Mapping object to override those in the slide master
+        """
+        override = self._element.clrMapOvr.color_map_override
+        if override is not None:
+            return ColorMap(override)
+        return None
 
 class SlideMasterPart(BaseSlidePart):
     """
@@ -308,6 +327,7 @@ class SlideMasterPart(BaseSlidePart):
         The color mapping of the theme
         """
         return ColorMap(self._element.clrMap)
+
 
 class ThemePart(XmlPart):
     """

--- a/pptx/parts/slide.py
+++ b/pptx/parts/slide.py
@@ -13,7 +13,7 @@ from ..opc.packuri import PackURI
 from ..oxml.slide import CT_NotesMaster, CT_NotesSlide, CT_Slide
 from ..oxml.theme import CT_OfficeStyleSheet
 from ..slide import NotesMaster, NotesSlide, Slide, SlideLayout, SlideMaster
-from ..theme import Theme
+from ..theme import Theme, ColorMap
 from ..util import lazyproperty
 
 
@@ -301,6 +301,13 @@ class SlideMasterPart(BaseSlidePart):
         """
         return self.part_related_by(RT.THEME).theme
     
+
+    @lazyproperty
+    def color_map(self):
+        """
+        The color mapping of the theme
+        """
+        return ColorMap(self._element.clrMap)
 
 class ThemePart(XmlPart):
     """

--- a/pptx/parts/slide.py
+++ b/pptx/parts/slide.py
@@ -313,7 +313,7 @@ class SlideMasterPart(BaseSlidePart):
         """
         return SlideMaster(self._element, self)
     
-
+    @property
     def related_theme(self):
         """
         The |Theme| object representing this part.

--- a/pptx/parts/slide.py
+++ b/pptx/parts/slide.py
@@ -12,7 +12,7 @@ from ..opc.package import XmlPart
 from ..opc.packuri import PackURI
 from ..oxml.slide import CT_NotesMaster, CT_NotesSlide, CT_Slide
 from ..oxml.theme import CT_OfficeStyleSheet
-from ..slide import NotesMaster, NotesSlide, Slide, SlideLayout, SlideMaster
+from ..slide import NotesMaster, NotesSlide, Slide, SlideLayout, SlideMaster, TextListStyle
 from ..theme import Theme, ColorMap
 from ..util import lazyproperty
 
@@ -327,6 +327,18 @@ class SlideMasterPart(BaseSlidePart):
         The color mapping of the theme
         """
         return ColorMap(self._element.clrMap)
+
+    @lazyproperty
+    def title_style(self):
+        return TextListStyle(self._element.txStyles.titleStyle)
+
+    @lazyproperty
+    def body_style(self):
+        return TextListStyle(self._element.txStyles.bodyStyle)
+
+    @lazyproperty
+    def other_style(self):
+        return TextListStyle(self._element.tsStyles.otherStyle)
 
 
 class ThemePart(XmlPart):

--- a/pptx/shapes/base.py
+++ b/pptx/shapes/base.py
@@ -133,6 +133,19 @@ class BaseShape(object):
     def name(self, value):
         self._element._nvXxPr.cNvPr.name = value
 
+    
+    @property
+    def hidden(self):
+        """
+        Read/write visiblity status of this shape.  Defaults to False
+        """
+        return self._element.hidden
+
+    @hidden.setter
+    def hidden(self, value):
+        self._element._nvXxPr.cNvPr.hidden = value
+
+    
     @property
     def part(self):
         """The package part containing this shape.

--- a/pptx/slide.py
+++ b/pptx/slide.py
@@ -478,6 +478,10 @@ class SlideMaster(_BaseMaster):
         """|Theme| object providing access to this slide-master's theme."""
         return self.part.related_theme
 
+    @property
+    def color_map(self):
+        return self.part.color_map
+
 
 class SlideMasters(ParentedElementProxy):
     """Sequence of |SlideMaster| objects belonging to a presentation.

--- a/pptx/slide.py
+++ b/pptx/slide.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from pptx.dml.fill import FillFormat
 from pptx.enum.shapes import PP_PLACEHOLDER
-from pptx.text.text import ParagraphProperties
+from pptx.text.text import TextListStyle
 from pptx.shapes.shapetree import (
     LayoutPlaceholders,
     LayoutShapes,
@@ -586,45 +586,4 @@ class _Background(ElementProxy):
         bgPr = self._cSld.get_or_add_bgPr()
         return FillFormat.from_fill_parent(bgPr)
 
-
-class TextListStyle(ElementProxy):
-    @property
-    def default(self):
-        return ParagraphProperties(self._element.defPPr)
-    
-    @property
-    def level_1(self):
-        return ParagraphProperties(self._element.lvl1pPr)
-
-    @property
-    def level_2(self):
-        return ParagraphProperties(self._element.lvl2pPr)
-
-    @property
-    def level_3(self):
-        return ParagraphProperties(self._element.lvl3pPr)
-
-    @property
-    def level_4(self):
-        return ParagraphProperties(self._element.lvl4pPr)
-
-    @property
-    def level_5(self):
-        return ParagraphProperties(self._element.lvl5pPr)
-
-    @property
-    def level_6(self):
-        return ParagraphProperties(self._element.lvl6pPr)
-
-    @property
-    def level_7(self):
-        return ParagraphProperties(self._element.lvl7pPr)
-
-    @property
-    def level_8(self):
-        return ParagraphProperties(self._element.lvl8pPr)
-
-    @property
-    def level_9(self):
-        return ParagraphProperties(self._element.lvl9pPr)
 

--- a/pptx/slide.py
+++ b/pptx/slide.py
@@ -487,7 +487,7 @@ class SlideMaster(_BaseMaster):
     @property
     def theme(self):
         """|Theme| object providing access to this slide-master's theme."""
-        return self.part.related_theme()
+        return self.part.related_theme
 
     @property
     def color_map(self):

--- a/pptx/slide.py
+++ b/pptx/slide.py
@@ -249,6 +249,11 @@ class Slide(_BaseSlide):
         |SlideLayout| object this slide inherits appearance from.
         """
         return self.part.slide_layout
+    
+    @property
+    def color_map_override(self):
+        """ A new |ColorMap| to override that from the Slide Master or None"""
+        return self.part.color_map_override
 
 
 class Slides(ParentedElementProxy):
@@ -381,6 +386,11 @@ class SlideLayout(_BaseSlide):
         deleted and inheritance from the master restored.
         """
         return self._element.bg is None
+
+    @property
+    def color_map_override(self):
+        """ A new |ColorMap| to override that from the Slide Master or None"""
+        return self.part.color_map_override
 
 class SlideLayouts(ParentedElementProxy):
     """Sequence of slide layouts belonging to a slide-master.

--- a/pptx/slide.py
+++ b/pptx/slide.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from pptx.dml.fill import FillFormat
 from pptx.enum.shapes import PP_PLACEHOLDER
+from pptx.text.text import ParagraphProperties
 from pptx.shapes.shapetree import (
     LayoutPlaceholders,
     LayoutShapes,
@@ -589,41 +590,41 @@ class _Background(ElementProxy):
 class TextListStyle(ElementProxy):
     @property
     def default(self):
-        return self._element.defPPr
+        return ParagraphProperties(self._element.defPPr)
     
     @property
     def level_1(self):
-        return self._element.lvl1pPr
+        return ParagraphProperties(self._element.lvl1pPr)
 
     @property
     def level_2(self):
-        return self._element.lvl2pPr
+        return ParagraphProperties(self._element.lvl2pPr)
 
     @property
     def level_3(self):
-        return self._element.lvl3pPr
+        return ParagraphProperties(self._element.lvl3pPr)
 
     @property
     def level_4(self):
-        return self._element.lvl4pPr
+        return ParagraphProperties(self._element.lvl4pPr)
 
     @property
     def level_5(self):
-        return self._element.lvl5pPr
+        return ParagraphProperties(self._element.lvl5pPr)
 
     @property
     def level_6(self):
-        return self._element.lvl6pPr
+        return ParagraphProperties(self._element.lvl6pPr)
 
     @property
     def level_7(self):
-        return self._element.lvl7pPr
+        return ParagraphProperties(self._element.lvl7pPr)
 
     @property
     def level_8(self):
-        return self._element.lvl8pPr
+        return ParagraphProperties(self._element.lvl8pPr)
 
     @property
     def level_9(self):
-        return self._element.lvl9pPr
+        return ParagraphProperties(self._element.lvl9pPr)
 

--- a/pptx/slide.py
+++ b/pptx/slide.py
@@ -487,7 +487,7 @@ class SlideMaster(_BaseMaster):
     @property
     def theme(self):
         """|Theme| object providing access to this slide-master's theme."""
-        return self.part.related_theme
+        return self.part.related_theme()
 
     @property
     def color_map(self):

--- a/pptx/slide.py
+++ b/pptx/slide.py
@@ -492,6 +492,18 @@ class SlideMaster(_BaseMaster):
     def color_map(self):
         return self.part.color_map
 
+    @property
+    def title_style(self):
+        return self.part.title_style
+
+    @property
+    def body_style(self):
+        return self.part.body_style
+    
+    @property
+    def other_style(self):
+        return self.part.other_style
+
 
 class SlideMasters(ParentedElementProxy):
     """Sequence of |SlideMaster| objects belonging to a presentation.
@@ -572,3 +584,46 @@ class _Background(ElementProxy):
         """
         bgPr = self._cSld.get_or_add_bgPr()
         return FillFormat.from_fill_parent(bgPr)
+
+
+class TextListStyle(ElementProxy):
+    @property
+    def default(self):
+        return self._element.defPPr
+    
+    @property
+    def level_1(self):
+        return self._element.lvl1pPr
+
+    @property
+    def level_2(self):
+        return self._element.lvl2pPr
+
+    @property
+    def level_3(self):
+        return self._element.lvl3pPr
+
+    @property
+    def level_4(self):
+        return self._element.lvl4pPr
+
+    @property
+    def level_5(self):
+        return self._element.lvl5pPr
+
+    @property
+    def level_6(self):
+        return self._element.lvl6pPr
+
+    @property
+    def level_7(self):
+        return self._element.lvl7pPr
+
+    @property
+    def level_8(self):
+        return self._element.lvl8pPr
+
+    @property
+    def level_9(self):
+        return self._element.lvl9pPr
+

--- a/pptx/text/bullets.py
+++ b/pptx/text/bullets.py
@@ -322,7 +322,6 @@ class _TextBulletColorSpecific(_TextBulletColor):
 
     @property
     def color(self):
-        print("COLORS")
         return ColorFormat.from_colorchoice_parent(self._bullet_color)
 
 

--- a/pptx/text/text.py
+++ b/pptx/text/text.py
@@ -851,3 +851,164 @@ class TextFont(ElementProxy):
     def charset(self):
         return self._element.charset
     
+
+class ParagraphProperties(ElementProxy):
+    @property
+    def alignment(self):
+        """
+        Horizontal alignment of this paragraph, represented by either
+        a member of the enumeration :ref:`PpParagraphAlignment` or |None|.
+        The value |None| indicates the paragraph should 'inherit' its
+        effective value from its style hierarchy. Assigning |None| removes
+        any explicit setting, causing its inherited value to be used.
+        """
+        return self._element.algn
+
+    @alignment.setter
+    def alignment(self, value):
+        self._element.algn = value
+
+    @property
+    def level(self):
+        """
+        Read-write integer indentation level of this paragraph, having a
+        range of 0-8 inclusive. 0 represents a top-level paragraph and is the
+        default value. Indentation level is most commonly encountered in a
+        bulleted list, as is found on a word bullet slide.
+        """
+        return self._element.lvl
+
+    @level.setter
+    def level(self, level):
+        self._element.lvl = level
+
+    @property
+    def margin_left(self):
+        """
+        Read/write integer value of left margin of paragraph as a |Length| value
+        object. If assigned |None|, the default value is used, 0 inches for
+        left and right margins.
+        """
+        return self._element.marL
+
+
+    @margin_left.setter
+    def margin_left(self, value):
+        self._element.marL = value
+
+    @property
+    def margin_right(self):
+        """
+        Read/write integer value of right margin of paragraph as a |Length| value
+        object. If assigned |None|, the default value is used, 0 inches for
+        left and right margins.
+        """
+        return self._element.marR
+
+    @margin_right.setter
+    def margin_right(self, value):
+        self._element.marR = value
+
+    @property
+    def indent(self):
+        """
+        Read/write integer value of indentation of first line of a paragraph
+        as a |Length| value object.  This value is calculated from the left
+        margin of the paragraph.  If assigned |None|, the default value is
+        used, 0.  Negative values can also be used.
+        """
+        return self._element.indent
+
+    @indent.setter
+    def indent(self, value):
+        self._element.indent = value
+
+
+    @property
+    def line_spacing(self):
+        """
+        Numeric or |Length| value specifying the space between baselines in
+        successive lines of this paragraph. A value of |None| indicates no
+        explicit value is assigned and its effective value is inherited from
+        the paragraph's style hierarchy. A numeric value, e.g. `2` or `1.5`,
+        indicates spacing is applied in multiples of line heights. A |Length|
+        value such as ``Pt(12)`` indicates spacing is a fixed height. The
+        |Pt| value class is a convenient way to apply line spacing in units
+        of points.
+        """
+        return self._element.line_spacing
+
+    @line_spacing.setter
+    def line_spacing(self, value):
+        self._element.line_spacing = value
+
+    @property
+    def space_after(self):
+        """
+        |Length| value specifying the spacing to appear between this
+        paragraph and the subsequent paragraph. A value of |None| indicates
+        no explicit value is assigned and its effective value is inherited
+        from the paragraph's style hierarchy. |Length| objects provide
+        convenience properties, such as ``.pt`` and ``.inches``, that allow
+        easy conversion to various length units.
+        """
+        return self._element.space_after
+
+    @space_after.setter
+    def space_after(self, value):
+        self._element.space_after = value
+
+    @property
+    def space_before(self):
+        """
+        |Length| value specifying the spacing to appear between this
+        paragraph and the prior paragraph. A value of |None| indicates no
+        explicit value is assigned and its effective value is inherited from
+        the paragraph's style hierarchy. |Length| objects provide convenience
+        properties, such as ``.pt`` and ``.cm``, that allow easy conversion
+        to various length units.
+        """
+        return self._element.space_before
+
+    @space_before.setter
+    def space_before(self, value):
+        self._element.space_before = value
+
+    @property
+    def _defRPr(self):
+        """
+        The |CT_TextCharacterProperties| instance (<a:defRPr> element) that
+        defines the default run properties for runs in this paragraph. Causes
+        the element to be added if not present.
+        """
+        return self._element.get_or_add_defRPr()
+
+    @property
+    def bullet_text(self):
+        """
+        The |TextBullet| Object that handles the formatting of bullets
+        """
+        return TextBullet.from_parent(self._element)
+       
+    @property
+    def bullet_color(self):
+        """
+        The |TextBulletColor| Object that handles the coloring of bullets
+        """
+        return TextBulletColor.from_parent(self._element)
+       
+    @property
+    def bullet_size(self):
+        """
+        The |TextBulletSize| Object that handles the sizing of bullets
+        """
+        return TextBulletSize.from_parent(self._element)
+       
+
+    @property
+    def bullet_font(self):
+        """
+        The |TextBulletTypeface| Object that handles the font typeface of bullets
+        """
+        return TextBulletTypeface.from_parent(self._element)
+

--- a/pptx/text/text.py
+++ b/pptx/text/text.py
@@ -529,6 +529,16 @@ class _Hyperlink(Subshape):
         self._rPr._remove_hlinkClick()
 
 
+    def add_hyperlink_color(self):
+        """
+        In order to add a color to a single hyperlink, a entry in the extList element
+        is required, along with a fill color in the run.  This function must be called
+        in order to add the appropriate `ext` element and its `ahyp:hlinkClr` child
+        """
+        ext_list = self._rPr.get_or_add_extList()
+        ext = ext_list.add_extension("{A12FA001-AC4F-418D-AE19-62706E023703}")
+        
+
 class _Paragraph(Subshape):
     """Paragraph object. Not intended to be constructed directly."""
 

--- a/pptx/text/text.py
+++ b/pptx/text/text.py
@@ -536,7 +536,10 @@ class _Hyperlink(Subshape):
         in order to add the appropriate `ext` element and its `ahyp:hlinkClr` child
         """
         ext_list = self._rPr.hlinkClick.get_or_add_extLst()
-        ext = ext_list.add_extension("{A12FA001-AC4F-418D-AE19-62706E023703}")
+        ext = ext_list.add_extension()
+        ext.uri = "{A12FA001-AC4F-418D-AE19-62706E023703}"
+        hyperlinkColor = ext.get_or_add_hyperlinkColor()
+        hyperlinkColor.val = "tx"
         
 
 class _Paragraph(Subshape):

--- a/pptx/text/text.py
+++ b/pptx/text/text.py
@@ -535,7 +535,7 @@ class _Hyperlink(Subshape):
         is required, along with a fill color in the run.  This function must be called
         in order to add the appropriate `ext` element and its `ahyp:hlinkClr` child
         """
-        ext_list = self._rPr.get_or_add_extList()
+        ext_list = self._rPr.hlinkClick.get_or_add_extLst()
         ext = ext_list.add_extension("{A12FA001-AC4F-418D-AE19-62706E023703}")
         
 

--- a/pptx/text/text.py
+++ b/pptx/text/text.py
@@ -282,6 +282,12 @@ class TextFrame(Subshape):
         for rPr in iter_rPrs(txBody):
             set_rPr_font(rPr, family, size, bold, italic)
 
+    @property
+    def list_style(self):
+        return TextListStyle(self._txBody.lstStyle)
+
+    
+
 
 class Font(object):
     """
@@ -852,7 +858,13 @@ class TextFont(ElementProxy):
         return self._element.charset
     
 
-class ParagraphProperties(ElementProxy):
+class ParagraphProperties(object):
+
+    def __init__(self, _pPr):
+        super(ParagraphProperties, self).__init__()
+        self._element = self._pPr = _pPr
+
+    
     @property
     def alignment(self):
         """
@@ -1011,4 +1023,57 @@ class ParagraphProperties(ElementProxy):
         The |TextBulletTypeface| Object that handles the font typeface of bullets
         """
         return TextBulletTypeface.from_parent(self._element)
+
+    @property
+    def font(self):
+        """
+        |Font| object containing default character properties for the runs in
+        this paragraph. These character properties override default properties
+        inherited from parent objects such as the text frame the paragraph is
+        contained in and they may be overridden by character properties set at
+        the run level.
+        """
+        return Font(self._defRPr)
+
+
+class TextListStyle(ElementProxy):
+    @property
+    def default(self):
+        return ParagraphProperties(self._element.get_or_add_defPPr())
+    
+    @property
+    def level_1(self):
+        return ParagraphProperties(self._element.get_or_add_lvl1pPr())
+
+    @property
+    def level_2(self):
+        return ParagraphProperties(self._element.lvl2pPr)
+
+    @property
+    def level_3(self):
+        return ParagraphProperties(self._element.lvl3pPr)
+
+    @property
+    def level_4(self):
+        return ParagraphProperties(self._element.lvl4pPr)
+
+    @property
+    def level_5(self):
+        return ParagraphProperties(self._element.lvl5pPr)
+
+    @property
+    def level_6(self):
+        return ParagraphProperties(self._element.lvl6pPr)
+
+    @property
+    def level_7(self):
+        return ParagraphProperties(self._element.lvl7pPr)
+
+    @property
+    def level_8(self):
+        return ParagraphProperties(self._element.lvl8pPr)
+
+    @property
+    def level_9(self):
+        return ParagraphProperties(self._element.lvl9pPr)
 

--- a/pptx/text/text.py
+++ b/pptx/text/text.py
@@ -550,11 +550,11 @@ class _Paragraph(Subshape):
         effective value from its style hierarchy. Assigning |None| removes
         any explicit setting, causing its inherited value to be used.
         """
-        return self._pPr.algn
+        return self._pPr.alignment
 
     @alignment.setter
     def alignment(self, value):
-        self._pPr.algn = value
+        self._pPr.alignment = value
 
     def clear(self):
         """
@@ -584,11 +584,11 @@ class _Paragraph(Subshape):
         default value. Indentation level is most commonly encountered in a
         bulleted list, as is found on a word bullet slide.
         """
-        return self._pPr.lvl
+        return self._pPr.level
 
     @level.setter
     def level(self, level):
-        self._pPr.lvl = level
+        self._pPr.level = level
 
     @property
     def margin_left(self):
@@ -597,12 +597,12 @@ class _Paragraph(Subshape):
         object. If assigned |None|, the default value is used, 0 inches for
         left and right margins.
         """
-        return self._pPr.marL
+        return self._pPr.margin_left
 
 
     @margin_left.setter
     def margin_left(self, value):
-        self._pPr.marL = value
+        self._pPr.margin_left = value
 
     @property
     def margin_right(self):
@@ -611,11 +611,11 @@ class _Paragraph(Subshape):
         object. If assigned |None|, the default value is used, 0 inches for
         left and right margins.
         """
-        return self._pPr.marR
+        return self._pPr.margin_right
 
     @margin_right.setter
     def margin_right(self, value):
-        self._pPr.marR = value
+        self._pPr.margin_right = value
 
     @property
     def indent(self):
@@ -741,7 +741,7 @@ class _Paragraph(Subshape):
         defines the default run properties for runs in this paragraph. Causes
         the element to be added if not present.
         """
-        return self._pPr.get_or_add_defRPr()
+        return self._pPr._defRPr
 
     @property
     def _pPr(self):
@@ -750,7 +750,7 @@ class _Paragraph(Subshape):
         <a:pPr> element containing its paragraph properties. Causes the
         element to be added if not present.
         """
-        return self._p.get_or_add_pPr()
+        return ParagraphProperties(self._p.get_or_add_pPr())
 
 
     @property
@@ -758,21 +758,21 @@ class _Paragraph(Subshape):
         """
         The |TextBullet| Object that handles the formatting of bullets
         """
-        return TextBullet.from_parent(self._pPr)
+        return self._pPr.bullet_text
        
     @property
     def bullet_color(self):
         """
         The |TextBulletColor| Object that handles the coloring of bullets
         """
-        return TextBulletColor.from_parent(self._pPr)
+        return self._pPr.bullet_color
        
     @property
     def bullet_size(self):
         """
         The |TextBulletSize| Object that handles the sizing of bullets
         """
-        return TextBulletSize.from_parent(self._pPr)
+        return self._pPr.bullet_size
        
 
     @property
@@ -780,7 +780,7 @@ class _Paragraph(Subshape):
         """
         The |TextBulletTypeface| Object that handles the font typeface of bullets
         """
-        return TextBulletTypeface.from_parent(self._pPr)
+        return self._pPr.bullet_font
 
 
 class _Run(Subshape):

--- a/pptx/theme.py
+++ b/pptx/theme.py
@@ -109,10 +109,20 @@ class ColorScheme(ElementProxy):
 
     @property
     def hyperlink(self):
-        return ColorFormat.from_colorchoice_parent(self._element.hlink)
+        """ Plain English propery name for `hlink`"""
+        return self.hlink
 
     @property
     def followed_hyperlink(self):
+        """ Plain English propery name for `folHlink`"""
+        return self.folHlink
+
+    @property
+    def hlink(self):
+        return ColorFormat.from_colorchoice_parent(self._element.hlink)
+
+    @property
+    def folHlink(self):
         return ColorFormat.from_colorchoice_parent(self._element.folHlink)
 
 

--- a/pptx/theme.py
+++ b/pptx/theme.py
@@ -160,3 +160,53 @@ class FontCollection(ElementProxy):
     @property
     def complex_script(self): 
         return TextFont(self.element.cs)
+
+class ColorMap(ElementProxy):
+    @property
+    def bg1(self):
+        return self.element.bg1
+
+    @property
+    def tx1(self):
+        return self.element.tx1
+    
+    @property
+    def bg2(self):
+        return self.element.bg2
+    
+    @property
+    def tx2(self):
+        return self.element.tx2
+    
+    @property
+    def accent1(self):
+        return self.element.accent1
+
+    @property
+    def accent2(self):
+        return self.element.accent2
+
+    @property
+    def accent3(self):
+        return self.element.accent3
+
+    @property
+    def accent4(self):
+        return self.element.accent4
+
+    @property
+    def accent5(self):
+        return self.element.accent5
+
+    @property
+    def accent6(self):
+        return self.element.accent6
+
+    @property
+    def hyperlink(self):
+        return self.element.hlink
+
+    @property
+    def followed_hyperlink(self):
+        return self.element.folHlink
+

--- a/tests/parts/test_slide.py
+++ b/tests/parts/test_slide.py
@@ -31,7 +31,7 @@ from pptx.parts.slide import (
     ThemePart,
 )
 from pptx.slide import NotesMaster, NotesSlide, Slide, SlideLayout, SlideMaster
-from pptx.theme import Theme
+from pptx.theme import Theme, ColorMap
 
 from ..unitutil.cxml import element
 from ..unitutil.file import absjoin, test_file_dir
@@ -764,9 +764,15 @@ class DescribeSlideMasterPart(object):
 
     def it_provides_access_to_its_related_theme(self, theme_fixture):
         slide_master_part, part_related_by_, theme_ = theme_fixture
-        theme = slide_master_part.related_theme()
+        theme = slide_master_part.related_theme
         part_related_by_.assert_called_once_with(slide_master_part, RT.THEME)
         assert theme is theme_
+
+    # def it_provides_access_to_its_color_map(self, color_map_fixture):
+    #     slide_master_part, color_map_ = color_map_fixture
+    #     color_map = slide_master_part.color_map
+    #     assert color_map is color_map_
+
 
     # fixtures -------------------------------------------------------
 
@@ -791,6 +797,12 @@ class DescribeSlideMasterPart(object):
         theme_part_.theme = theme_
         return slide_master_part, part_related_by_, theme_
 
+    @pytest.fixture
+    def color_map_fixture(self, color_map_):
+        sldMaster = element("p:sldMaster/p:clrMap")
+        slide_master_part = SlideMasterPart(None, None, sldMaster)
+        return slide_master_part, color_map_
+
     # fixture components ---------------------------------------------
 
     @pytest.fixture
@@ -804,6 +816,10 @@ class DescribeSlideMasterPart(object):
     @pytest.fixture
     def theme_(self, request):
         return instance_mock(request, Theme)
+
+    @pytest.fixture
+    def color_map_(self, request):
+        return instance_mock(request, ColorMap)
 
     @pytest.fixture
     def SlideMaster_(self, request, slide_master_):


### PR DESCRIPTION
Within the Slide Master (and also in Slide Layouts to a much lesser extent) is a lot of default formatting that we need access to in order to better implement the Slide Importer and Builder.  In order to access all of these details, I've added a lot more functionality into how we are accessing Slide Masters.  We now have access to the Color Mapping element as well as all of the style lists.  

Unlike most of our previous additions, this actually required updating a few things in the existing code.  While we were already accessing most of the Paragraph Property elements directly from the `_Paragraph` class, there wasn't an existing class to correspond to this `pPr` element.  Since I needed that class to handle all of the other styles created within the Master Slides, I went ahead and created that class.  I then updated the various calls to it in `_Paragraph` simply to unify things a bit.  Everything is working nicely.

I have also added a couple new features that are color related as well.  I have added proper SCRGB color handling as well as adding a new color to the THEME_COLOR enum that is a placeholder and simply indicates to use the associated style color. I don't see any need for us to use either of these in Deckbot but they were needed for processing in the Slidebuilder.  Additionally, I added access to the "hidden" attribute for shapes so we can ignore them in the SlideBuilder if they are hidden.  

Most, if not all, of these new features will actually probably never be used by Deckbot outside of the SlideBuilder but are important for the importing/processing components of the SlideBuilder.

Also, I haven't added Unit tests yet.  Figured I'd do that in a separate ticket since there was already a lot here.