### PR TITLE
DB-1051 - Individual Hyperlink Colors

### DIFF
--- a/pptx/dml/fill.py
+++ b/pptx/dml/fill.py
@@ -380,6 +380,11 @@ class _GradientStops(Sequence):
         return len(self._gsLst)
 
 
+    def add_gradient_stop(self):
+        self._gsLst.add_gs()
+        return _GradientStop(self._gsLst[-1])
+
+
 class _GradientStop(ElementProxy):
     """A single gradient stop.
 

--- a/pptx/oxml/__init__.py
+++ b/pptx/oxml/__init__.py
@@ -574,3 +574,9 @@ register_element_cls("a:folHlink", CT_Color)
 register_element_cls("a:majorFont", CT_FontCollection)
 register_element_cls("a:minorFont", CT_FontCollection)
 register_element_cls("a:masterClrMapping", CT_EmptyElement)
+
+
+from .media import (
+    CT_OfficeArtExtensionList,  # noqa: E402
+)
+register_element_cls("a:extList", CT_OfficeArtExtensionList)

--- a/pptx/oxml/__init__.py
+++ b/pptx/oxml/__init__.py
@@ -579,4 +579,4 @@ register_element_cls("a:masterClrMapping", CT_EmptyElement)
 from .media import (
     CT_OfficeArtExtensionList,  # noqa: E402
 )
-register_element_cls("a:extList", CT_OfficeArtExtensionList)
+register_element_cls("a:extLst", CT_OfficeArtExtensionList)

--- a/pptx/oxml/__init__.py
+++ b/pptx/oxml/__init__.py
@@ -52,10 +52,11 @@ def register_element_cls(nsptagname, cls):
     namespace[nsptag.local_part] = cls
 
 
-from .action import CT_Hyperlink  # noqa: E402
+from .action import CT_Hyperlink, HyperlinkColorExtension  # noqa: E402
 
 register_element_cls("a:hlinkClick", CT_Hyperlink)
 register_element_cls("a:hlinkHover", CT_Hyperlink)
+register_element_cls("ahyp:hlinkClr", HyperlinkColorExtension)
 
 
 from .chart.axis import (  # noqa: E402

--- a/pptx/oxml/action.py
+++ b/pptx/oxml/action.py
@@ -7,7 +7,7 @@ lxml custom element classes for text-related XML elements.
 from __future__ import absolute_import
 
 from .simpletypes import XsdString
-from .xmlchemy import BaseOxmlElement, OptionalAttribute
+from .xmlchemy import BaseOxmlElement, ZeroOrOne, OptionalAttribute
 
 
 class CT_Hyperlink(BaseOxmlElement):
@@ -17,6 +17,7 @@ class CT_Hyperlink(BaseOxmlElement):
 
     rId = OptionalAttribute("r:id", XsdString)
     action = OptionalAttribute("action", XsdString)
+    extLst = ZeroOrOne("a:extLst", successors=())
 
     @property
     def action_fields(self):

--- a/pptx/oxml/action.py
+++ b/pptx/oxml/action.py
@@ -7,7 +7,7 @@ lxml custom element classes for text-related XML elements.
 from __future__ import absolute_import
 
 from .simpletypes import XsdString
-from .xmlchemy import BaseOxmlElement, ZeroOrOne, OptionalAttribute
+from .xmlchemy import BaseOxmlElement, ZeroOrOne, OptionalAttribute, RequiredAttribute
 
 
 class CT_Hyperlink(BaseOxmlElement):
@@ -58,3 +58,13 @@ class CT_Hyperlink(BaseOxmlElement):
         host = protocol_and_host[11:]
 
         return host
+
+
+
+class HyperlinkColorExtension(BaseOxmlElement):
+    """
+    Custom class to handle `ahyp:hlinkClr` child of `a:ext`
+    that is used for coloring individual hyperlinks
+    """
+    val = RequiredAttribute("val", XsdString)
+    

--- a/pptx/oxml/dml/fill.py
+++ b/pptx/oxml/dml/fill.py
@@ -14,6 +14,7 @@ from pptx.oxml.simpletypes import (
     ST_PositiveFixedAngle,
     ST_PositiveFixedPercentage,
     ST_RelationshipId,
+    XsdBoolean,
 )
 from pptx.oxml.xmlchemy import (
     BaseOxmlElement,
@@ -60,6 +61,8 @@ class CT_GradientFillProperties(BaseOxmlElement):
     lin = ZeroOrOne("a:lin", successors=_tag_seq[2:])
     path = ZeroOrOne("a:path", successors=_tag_seq[3:])
     del _tag_seq
+
+    rotWithShape = OptionalAttribute("rotWithShape", XsdBoolean)
 
     @classmethod
     def new_gradFill(cls):

--- a/pptx/oxml/media.py
+++ b/pptx/oxml/media.py
@@ -1,0 +1,22 @@
+# encoding: utf-8
+
+"""
+lxml custom element classes for ext-related XML elements.
+"""
+
+from __future__ import absolute_import
+
+from .xmlchemy import ZeroOrMore
+
+
+class CT_OfficeArtExtensionList(BaseOxmlElement):
+    """
+    Custom element class for <a:CT_OfficeArtExtensionList> elements.
+    """
+    ext = ZeroOrMore("a:ext")
+    
+    def add_extension(self, uri):
+        ext = self._add_ext()
+        ext.uri = uri
+        hyperlinkColor = ext.get_or_add_hyperlinkColor()
+        return ext

--- a/pptx/oxml/media.py
+++ b/pptx/oxml/media.py
@@ -6,7 +6,7 @@ lxml custom element classes for ext-related XML elements.
 
 from __future__ import absolute_import
 
-from .xmlchemy import ZeroOrMore
+from .xmlchemy import ZeroOrMore, BaseOxmlElement
 
 
 class CT_OfficeArtExtensionList(BaseOxmlElement):

--- a/pptx/oxml/media.py
+++ b/pptx/oxml/media.py
@@ -15,8 +15,6 @@ class CT_OfficeArtExtensionList(BaseOxmlElement):
     """
     ext = ZeroOrMore("a:ext")
     
-    def add_extension(self, uri):
+    def add_extension(self):
         ext = self._add_ext()
-        ext.uri = uri
-        hyperlinkColor = ext.get_or_add_hyperlinkColor()
         return ext

--- a/pptx/oxml/ns.py
+++ b/pptx/oxml/ns.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import
 #: namespaces.
 _nsmap = {
     "a": ("http://schemas.openxmlformats.org/drawingml/2006/main"),
+    "ahyp": ("http://schemas.microsoft.com/office/drawing/2018/hyperlinkcolor"),
     "c": ("http://schemas.openxmlformats.org/drawingml/2006/chart"),
     "cp": (
         "http://schemas.openxmlformats.org/package/2006/metadata/core-pro" "perties"

--- a/pptx/oxml/shapes/shared.py
+++ b/pptx/oxml/shapes/shared.py
@@ -30,6 +30,7 @@ from pptx.oxml.xmlchemy import (
     ZeroOrOne,
     ZeroOrOneChoice,
     OneAndOnlyOne,
+    ZeroOrMore,
 )
 from pptx.util import Emu
 
@@ -356,10 +357,17 @@ class CT_Point2D(BaseOxmlElement):
 class CT_PositiveSize2D(BaseOxmlElement):
     """
     Custom element class for <a:ext> element.
+
+    NOTE: this is a composite including `CT_OfficeArtExtension`, which appears
+    with the `a:extLst` tag in many different elements.  It currently only implements
+    the inclusion of the optional URI tag and a single `ext` element for hyperlink color.
     """
+
+    hyperlinkColor = ZeroOrOne("ahyp:hlinkClr")
 
     cx = RequiredAttribute("cx", ST_PositiveCoordinate)
     cy = RequiredAttribute("cy", ST_PositiveCoordinate)
+    uri = OptionalAttribute("uri", XsdString)
 
 
 class CT_ShapeProperties(BaseOxmlElement):

--- a/pptx/oxml/text.py
+++ b/pptx/oxml/text.py
@@ -312,7 +312,7 @@ class CT_TextCharacterProperties(BaseOxmlElement):
     hlinkClick = ZeroOrOne(
         "a:hlinkClick", successors=("a:hlinkMouseOver", "a:rtl", "a:extLst")
     )
-
+    extList = ZeroOrOne("a:extList", successors=())
     lang = OptionalAttribute("lang", MSO_LANGUAGE_ID)
     sz = OptionalAttribute("sz", ST_TextFontSize)
     b = OptionalAttribute("b", XsdBoolean)
@@ -320,7 +320,7 @@ class CT_TextCharacterProperties(BaseOxmlElement):
     u = OptionalAttribute("u", MSO_TEXT_UNDERLINE_TYPE)
     baseline = OptionalAttribute("baseline", ST_Percentage)
     strike = OptionalAttribute("strike", ST_TextStrikeType)
-    
+
     def _new_gradFill(self):
         return CT_GradientFillProperties.new_gradFill()
 

--- a/pptx/oxml/text.py
+++ b/pptx/oxml/text.py
@@ -312,7 +312,6 @@ class CT_TextCharacterProperties(BaseOxmlElement):
     hlinkClick = ZeroOrOne(
         "a:hlinkClick", successors=("a:hlinkMouseOver", "a:rtl", "a:extLst")
     )
-    extList = ZeroOrOne("a:extList", successors=())
     lang = OptionalAttribute("lang", MSO_LANGUAGE_ID)
     sz = OptionalAttribute("sz", ST_TextFontSize)
     b = OptionalAttribute("b", XsdBoolean)

--- a/pptx/text/text.py
+++ b/pptx/text/text.py
@@ -529,6 +529,16 @@ class _Hyperlink(Subshape):
         self._rPr._remove_hlinkClick()
 
 
+    def add_hyperlink_color(self):
+        """
+        In order to add a color to a single hyperlink, a entry in the extList element
+        is required, along with a fill color in the run.  This function must be called
+        in order to add the appropriate `ext` element and its `ahyp:hlinkClr` child
+        """
+        ext_list = self._rPr.get_or_add_extList()
+        ext = ext_list.add_extension("{A12FA001-AC4F-418D-AE19-62706E023703}")
+        
+
 class _Paragraph(Subshape):
     """Paragraph object. Not intended to be constructed directly."""
 

--- a/pptx/text/text.py
+++ b/pptx/text/text.py
@@ -536,7 +536,10 @@ class _Hyperlink(Subshape):
         in order to add the appropriate `ext` element and its `ahyp:hlinkClr` child
         """
         ext_list = self._rPr.hlinkClick.get_or_add_extLst()
-        ext = ext_list.add_extension("{A12FA001-AC4F-418D-AE19-62706E023703}")
+        ext = ext_list.add_extension()
+        ext.uri = "{A12FA001-AC4F-418D-AE19-62706E023703}"
+        hyperlinkColor = ext.get_or_add_hyperlinkColor()
+        hyperlinkColor.val = "tx"
         
 
 class _Paragraph(Subshape):

--- a/pptx/text/text.py
+++ b/pptx/text/text.py
@@ -535,7 +535,7 @@ class _Hyperlink(Subshape):
         is required, along with a fill color in the run.  This function must be called
         in order to add the appropriate `ext` element and its `ahyp:hlinkClr` child
         """
-        ext_list = self._rPr.get_or_add_extList()
+        ext_list = self._rPr.hlinkClick.get_or_add_extLst()
         ext = ext_list.add_extension("{A12FA001-AC4F-418D-AE19-62706E023703}")
         
 

--- a/pptx/theme.py
+++ b/pptx/theme.py
@@ -109,10 +109,20 @@ class ColorScheme(ElementProxy):
 
     @property
     def hyperlink(self):
-        return ColorFormat.from_colorchoice_parent(self._element.hlink)
+        """ Plain English propery name for `hlink`"""
+        return self.hlink
 
     @property
     def followed_hyperlink(self):
+        """ Plain English propery name for `folHlink`"""
+        return self.folHlink
+
+    @property
+    def hlink(self):
+        return ColorFormat.from_colorchoice_parent(self._element.hlink)
+
+    @property
+    def folHlink(self):
         return ColorFormat.from_colorchoice_parent(self._element.folHlink)
 
 


### PR DESCRIPTION
This turned out to be so much more complicated than it had any need to be.  

In order to format a hyperlink, we not only format the run with appropriate color but we also have to add a chunk of xml that points at some sort of extension.  Honestly, I don't really understand it but it works.  

What ultimately made it so difficult is that this involved using an XML tag `<a:ext>` which has two totally separate meanings within Powerpoint and is already being used elsewhere.  This meant that I couldn't simply register that tag and assign it to a ComplexType as usual.  After doing some research, someone actually had posted on the original github repo about this recently and Steve had responded.  His approach was to basically combine the two ComplexTypes.  It's ugly but its working.  Fortunately, the tag is simple with a single attribute so it works.

From a user's perspective, for us to add this, we have to call a function `hyperlink.add_hyperlink_color()` and then it will build that xml tag for us.  It's not ideal but it works and implementing full support for the whole `<a:extLst>` and `<a:ext>` is super complicated and not something we need.  I tried to make the implementation as abstract as possible so we can reuse it elsewhere.

Ultimately, it isn't pretty but it works.  Full integration for Deckbot over in DB-1113