### PR TITLE
DB-957 - Add Gradient Stop

### DIFF
--- a/pptx/dml/fill.py
+++ b/pptx/dml/fill.py
@@ -380,6 +380,11 @@ class _GradientStops(Sequence):
         return len(self._gsLst)
 
 
+    def add_gradient_stop(self):
+        self._gsLst.add_gs()
+        return _GradientStop(self._gsLst[-1])
+
+
 class _GradientStop(ElementProxy):
     """A single gradient stop.
 

--- a/pptx/oxml/dml/fill.py
+++ b/pptx/oxml/dml/fill.py
@@ -14,6 +14,7 @@ from pptx.oxml.simpletypes import (
     ST_PositiveFixedAngle,
     ST_PositiveFixedPercentage,
     ST_RelationshipId,
+    XsdBoolean,
 )
 from pptx.oxml.xmlchemy import (
     BaseOxmlElement,
@@ -60,6 +61,8 @@ class CT_GradientFillProperties(BaseOxmlElement):
     lin = ZeroOrOne("a:lin", successors=_tag_seq[2:])
     path = ZeroOrOne("a:path", successors=_tag_seq[3:])
     del _tag_seq
+
+    rotWithShape = OptionalAttribute("rotWithShape", XsdBoolean)
 
     @classmethod
     def new_gradFill(cls):


### PR DESCRIPTION
While we technically didn't need this new function, it is a cleaner implementation and we don't have to call private methods from outside of the library.  This should work for us moving forward.  Pretty simple, it allows us to add a new gradient stop which then you then do update with proper values as it just adds a default stop.