### PR TITLE
DB-1117 - Custom Geometry Support

### DIFF
--- a/pptx/oxml/__init__.py
+++ b/pptx/oxml/__init__.py
@@ -307,11 +307,18 @@ from .shapes.autoshape import (  # noqa: E402
     CT_PresetGeometry2D,
     CT_Shape,
     CT_ShapeNonVisual,
+    CT_ConnectionSiteList,
+    CT_GeomRect,
+    CT_ConnectionSite,
 )
 
 register_element_cls("a:avLst", CT_GeomGuideList)
+register_element_cls("a:gdLst", CT_GeomGuideList)
+register_element_cls("a:cxnLst", CT_ConnectionSiteList)
 register_element_cls("a:custGeom", CT_CustomGeometry2D)
+register_element_cls("a:rect", CT_GeomRect)
 register_element_cls("a:gd", CT_GeomGuide)
+register_element_cls("a:cxn", CT_ConnectionSite)
 register_element_cls("a:close", CT_Path2DClose)
 register_element_cls("a:lnTo", CT_Path2DLineTo)
 register_element_cls("a:moveTo", CT_Path2DMoveTo)
@@ -319,6 +326,7 @@ register_element_cls("a:path", CT_Path2D)
 register_element_cls("a:pathLst", CT_Path2DList)
 register_element_cls("a:prstGeom", CT_PresetGeometry2D)
 register_element_cls("a:pt", CT_AdjPoint2D)
+register_element_cls("a:pos", CT_AdjPoint2D)
 register_element_cls("p:cNvSpPr", CT_NonVisualDrawingShapeProps)
 register_element_cls("p:nvSpPr", CT_ShapeNonVisual)
 register_element_cls("p:sp", CT_Shape)

--- a/pptx/oxml/__init__.py
+++ b/pptx/oxml/__init__.py
@@ -310,6 +310,9 @@ from .shapes.autoshape import (  # noqa: E402
     CT_ConnectionSiteList,
     CT_GeomRect,
     CT_ConnectionSite,
+    CT_Path2DArcTo,
+    CT_Path2DQuadBezierTo,
+    CT_Path2DCubicBezierTo,
 )
 
 register_element_cls("a:avLst", CT_GeomGuideList)
@@ -322,6 +325,9 @@ register_element_cls("a:cxn", CT_ConnectionSite)
 register_element_cls("a:close", CT_Path2DClose)
 register_element_cls("a:lnTo", CT_Path2DLineTo)
 register_element_cls("a:moveTo", CT_Path2DMoveTo)
+register_element_cls("a:arcTo", CT_Path2DArcTo)
+register_element_cls("a:quadBezTo", CT_Path2DQuadBezierTo)
+register_element_cls("a:cubicBezTo", CT_Path2DCubicBezierTo)
 register_element_cls("a:path", CT_Path2D)
 register_element_cls("a:pathLst", CT_Path2DList)
 register_element_cls("a:prstGeom", CT_PresetGeometry2D)

--- a/pptx/oxml/shapes/autoshape.py
+++ b/pptx/oxml/shapes/autoshape.py
@@ -229,7 +229,7 @@ class CT_Path2DCubicBezierTo(BaseOxmlElement):
 class CT_Path2DMoveTo(BaseOxmlElement):
     """`a:moveTo` custom element class."""
     # Should be OneAndOnlyOne()
-    pt = ZeroOrOne("a:pt")
+    pt = ZeroOrOne("a:pt", successors=())
 
 
 class CT_PresetGeometry2D(BaseOxmlElement):

--- a/pptx/oxml/shapes/shared.py
+++ b/pptx/oxml/shapes/shared.py
@@ -395,8 +395,13 @@ class CT_ShapeProperties(BaseOxmlElement):
         "a:extLst",
     )
     xfrm = ZeroOrOne("a:xfrm", successors=_tag_seq[1:])
-    custGeom = ZeroOrOne("a:custGeom", successors=_tag_seq[2:])
-    prstGeom = ZeroOrOne("a:prstGeom", successors=_tag_seq[3:])
+    eg_Geometry = ZeroOrOneChoice(
+        (
+            Choice("a:custGeom"),
+            Choice("a:prstGeom")
+        ),
+        successors=_tag_seq[3:]
+    )
     eg_fillProperties = ZeroOrOneChoice(
         (
             Choice("a:noFill"),

--- a/pptx/oxml/simpletypes.py
+++ b/pptx/oxml/simpletypes.py
@@ -1019,3 +1019,23 @@ class ST_ColorSchemeIndex(XsdTokenEnumeration):
     )
     _members = color_values
 
+class ST_AdjCoordinate(BaseSimpleType):
+    """
+    This techincally is a Union of ST_Coordinate and ST_GeomGuideName,
+    but I haven't figured out how to do that so I'm creating this for now
+    and we can add verification here if we need to
+    """
+    @classmethod
+    def convert_from_xml(cls, str_value):
+        return str_value
+
+    @classmethod
+    def convert_to_xml(cls, value):
+        return value
+
+    @classmethod
+    def validate(cls, value):
+        pass
+        # cls.validate_string(value)
+
+

--- a/pptx/oxml/simpletypes.py
+++ b/pptx/oxml/simpletypes.py
@@ -1031,7 +1031,7 @@ class ST_AdjCoordinate(BaseSimpleType):
 
     @classmethod
     def convert_to_xml(cls, value):
-        return value
+        return str(value)
 
     @classmethod
     def validate(cls, value):
@@ -1051,7 +1051,7 @@ class ST_AdjAngle(BaseSimpleType):
 
     @classmethod
     def convert_to_xml(cls, value):
-        return value
+        return str(value)
 
     @classmethod
     def validate(cls, value):

--- a/pptx/oxml/simpletypes.py
+++ b/pptx/oxml/simpletypes.py
@@ -1001,7 +1001,7 @@ class ST_PresetColorVal(XsdTokenEnumeration):
 
 class ST_ColorSchemeIndex(XsdTokenEnumeration):
     """
-    Valid vlaues for scheme color attribute
+    Valid values for scheme color attribute
     """
     color_values = (
         "dk1",
@@ -1038,4 +1038,38 @@ class ST_AdjCoordinate(BaseSimpleType):
         pass
         # cls.validate_string(value)
 
+
+class ST_AdjAngle(BaseSimpleType):
+    """
+    This techincally is a Union of ST_Angle and ST_GeomGuideName,
+    but I haven't figured out how to do that so I'm creating this for now
+    and we can add verification here if we need to
+    """
+    @classmethod
+    def convert_from_xml(cls, str_value):
+        return str_value
+
+    @classmethod
+    def convert_to_xml(cls, value):
+        return value
+
+    @classmethod
+    def validate(cls, value):
+        pass
+        # cls.validate_string(value)
+
+
+class ST_PathFillMode(XsdTokenEnumeration):
+    """
+    Valid values for path fill modes
+    """
+    fill_modes = (
+        "none",
+        "norm",
+        "lighten",
+        "lightenLess",
+        "darken",
+        "darkenLess",
+    )
+    _members = fill_modes
 

--- a/pptx/shapes/base.py
+++ b/pptx/shapes/base.py
@@ -274,6 +274,14 @@ class BaseShape(object):
     @flip_v.setter
     def flip_v(self, value):
         self._element.flipV = value
+
+    @property
+    def custom_geometry(self):
+        if not self._element.has_custom_geometry:
+            return None
+        else:
+            return CustomGeometry(self._element.custGeom)
+
         
         
 
@@ -372,4 +380,162 @@ class StyleMatrixReference(object):
     @idx.setter
     def idx(self, value):
         self._reference.idx = value
+
+
+class CustomGeometry(ElementProxy):
+    """
+    Class that proxies the ``<a:custGeom>`` tag used for
+    custom shape geometry.  
+    """
+
+    @property
+    def adjust_values(self):
+        return GeometryGuideList(self._element.avLst)
+
+    @property
+    def shape_guides(self):
+        return GeometryGuideList(self._element.gdLst)
+
+    # @property
+    # def shape_handles(self):
+    #     return self._element.ahLst
+
+    @property
+    def connection_sites(self):
+        return ConnectionSiteList(self._element.cxnLst)
+
+    @property
+    def rectangle(self):
+        return GeometricRectangle(self._element.rect)
+
+    @property
+    def paths(self):
+        return self._element.pathLst
+
+
+class GeometryGuideList(object):
+    """List of Shape Guides used by |CustomGeometry|.
+    """
+
+    def __init__(self, guide_list):
+        super(GeometryGuideList, self).__init__()
+        self._element = guide_list
+
+    @property
+    def guide_list(self):
+        gd = self._element.gd_lst
+        if gd is None:
+            return []
+        return [GeometryGuide(guide) for guide in gd]
+
+    def add_guide(self):
+        return GeometryGuide(self._element._add_gd())
+
+
+class GeometryGuide(object):
+    def __init__(self, guide):
+        super(GeometryGuide, self).__init__()
+        self._element = guide
+    
+    @property
+    def name(self):
+        return self._element.name
+
+    @name.setter
+    def name(self, value):
+        self._element.name = value
+
+    @property
+    def formula(self):
+        return self._element.fmla
+
+    @formula.setter
+    def formula(self, value):
+        self._element.fmla = value
+
+
+class ConnectionSiteList(object):
+    """List of Connection Sites used by |CustomGeometry|.
+    """
+
+    def __init__(self, cxn_site_list):
+        super(ConnectionSiteList, self).__init__()
+        self._element = cxn_site_list
+
+    @property
+    def sites_list(self):
+        sites = self._element.cxn_lst
+        if sites is None:
+            return []
+        return [ConnectionSite(site) for site in sites]
+
+    def add_site(self):
+        return ConnectionSite(self._element._add_cxn())
+
+
+class ConnectionSite(object):
+    def __init__(self, site):
+        super(ConnectionSite, self).__init__()
+        self._element = site
+    
+    @property
+    def angle(self):
+        return self._element.ang
+
+    @angle.setter
+    def angle(self, value):
+        self._element.ang = value
+
+    @property
+    def position(self):
+        pos = self._element.pos
+        return (pos.x, pos.y)
+
+    @position.setter
+    def position(self, coords):
+        pos = self._element.pos
+        pos.x = coords[0]
+        pos.y = coords[1]
+        
+
+class GeometricRectangle(object):
+    """ Object to define a rectangle for a textbox used by |CustomGeometry|
+    """
+
+    def __init__(self, rectangle):
+        super(GeometricRectangle, self).__init__()
+        self._element = rectangle
+    
+    @property
+    def left(self):
+        return self._element.l
+    
+    @left.setter
+    def left(self, value):
+        self._element.l = value
+
+    @property
+    def right(self):
+        return self._element.r
+    
+    @right.setter
+    def right(self, value):
+        self._element.r = value
+
+    @property
+    def top(self):
+        return self._element.t
+    
+    @top.setter
+    def top(self, value):
+        self._element.t = value
+
+    @property
+    def bottom(self):
+        return self._element.b
+    
+    @bottom.setter
+    def bottom(self, value):
+        self._element.b = value
+
 

--- a/pptx/shapes/base.py
+++ b/pptx/shapes/base.py
@@ -282,7 +282,10 @@ class BaseShape(object):
         else:
             return CustomGeometry(self._element.custGeom)
 
-        
+    def add_custom_geometry(self):
+        if self._element.has_custom_geometry:
+            return CustomGeometry(self._element.custGeom)
+        return CustomGeometry(self._element.spPr._add_custGeom())
         
 
 class _PlaceholderFormat(ElementProxy):
@@ -390,11 +393,11 @@ class CustomGeometry(ElementProxy):
 
     @property
     def adjust_values(self):
-        return GeometryGuideList(self._element.avLst)
+        return GeometryGuideList(self._element.get_or_add_avLst())
 
     @property
     def shape_guides(self):
-        return GeometryGuideList(self._element.gdLst)
+        return GeometryGuideList(self._element.get_or_add_gdLst())
 
     # @property
     # def shape_handles(self):
@@ -402,15 +405,15 @@ class CustomGeometry(ElementProxy):
 
     @property
     def connection_sites(self):
-        return ConnectionSiteList(self._element.cxnLst)
+        return ConnectionSiteList(self._element.get_or_add_cxnLst())
 
     @property
     def rectangle(self):
-        return GeometricRectangle(self._element.rect)
+        return GeometricRectangle(self._element.get_or_add_rect())
 
     @property
     def paths(self):
-        return self._element.pathLst
+        return PathList(self._element.get_or_add_pathLst())
 
 
 class GeometryGuideList(object):
@@ -493,7 +496,7 @@ class ConnectionSite(object):
 
     @position.setter
     def position(self, coords):
-        pos = self._element.pos
+        pos = self._element.get_or_add_pos()
         pos.x = coords[0]
         pos.y = coords[1]
         
@@ -537,5 +540,98 @@ class GeometricRectangle(object):
     @bottom.setter
     def bottom(self, value):
         self._element.b = value
+
+
+class PathList(object):
+    """List of Shape Paths used by |CustomGeometry|.
+    """
+
+    def __init__(self, path_list):
+        super(PathList, self).__init__()
+        self._element = path_list
+
+    @property
+    def path_list(self):
+        paths = self._element.path_lst
+        if paths is None:
+            return []
+        return [ShapePath(path) for path in paths]
+
+    def add_path(self):
+        return ShapePath(self._element._add_path())
+
+
+class ShapePath(object):
+    def __init__(self, path):
+        super(ShapePath, self).__init__()
+        self._element = path
+    
+    @property
+    def width(self):
+        return self._element.w
+
+    @width.setter
+    def width(self, value):
+        self._element.w = value
+
+    @property
+    def height(self):
+        return self._element.h
+
+    @height.setter
+    def height(self, value):
+        self._element.h = value
+
+    @property
+    def fill_mode(self):
+        return self._element.fill
+
+    @fill_mode.setter
+    def fill_mode(self, value):
+        self._element.fill = value
+
+    @property
+    def stroke(self):
+        return self._element.stroke
+
+    @stroke.setter
+    def stroke(self, value):
+        self._element.stroke = value
+
+    @property
+    def extrusion(self):
+        return self._element.extrusionOk
+
+    @extrusion.setter
+    def extrusion(self, value):
+        self._element.extrusionOk = value
+
+    def add_close(self):
+        return self._element.add_close()
+
+    def add_line_to(self, x, y):
+        return self._element.add_lnTo(x,y)
+
+    def add_move_to(self, x, y):
+        return self._element.add_moveTo(x, y)
+
+    def add_arc_to(self, width_radius, height_radius, start_angle, swing_angle):
+        return self._element.add_arcTo(width_radius, height_radius, start_angle, swing_angle)
+    
+    def add_quad_bez_to(self, point1, point2):
+        return self._element.add_quadBezTo(point1, point2)
+
+    def add_cubic_bez_to(self, point1, point2, point3):
+        return self._element.add_cubicBezTo(point1, point2, point3)
+
+    @property
+    def xml(self):
+        return self._element.xml
+
+    @property
+    def path_sequence(self):
+        return list(self._element)
+            
+
 
 

--- a/pptx/shapes/base.py
+++ b/pptx/shapes/base.py
@@ -416,7 +416,7 @@ class CustomGeometry(ElementProxy):
         return PathList(self._element.get_or_add_pathLst())
 
 
-class GeometryGuideList(object):
+class GeometryGuideList(ElementProxy):
     """List of Shape Guides used by |CustomGeometry|.
     """
 
@@ -435,7 +435,9 @@ class GeometryGuideList(object):
         return GeometryGuide(self._element._add_gd())
 
 
-class GeometryGuide(object):
+class GeometryGuide(ElementProxy):
+    """ Individual Geometry Guides for elements `a:gd`
+    """
     def __init__(self, guide):
         super(GeometryGuide, self).__init__()
         self._element = guide
@@ -457,7 +459,7 @@ class GeometryGuide(object):
         self._element.fmla = value
 
 
-class ConnectionSiteList(object):
+class ConnectionSiteList(ElementProxy):
     """List of Connection Sites used by |CustomGeometry|.
     """
 
@@ -476,7 +478,9 @@ class ConnectionSiteList(object):
         return ConnectionSite(self._element._add_cxn())
 
 
-class ConnectionSite(object):
+class ConnectionSite(ElementProxy):
+    """ Connection Sites represented by `a:cxn`
+    """
     def __init__(self, site):
         super(ConnectionSite, self).__init__()
         self._element = site
@@ -501,7 +505,7 @@ class ConnectionSite(object):
         pos.y = coords[1]
         
 
-class GeometricRectangle(object):
+class GeometricRectangle(ElementProxy):
     """ Object to define a rectangle for a textbox used by |CustomGeometry|
     """
 
@@ -542,7 +546,7 @@ class GeometricRectangle(object):
         self._element.b = value
 
 
-class PathList(object):
+class PathList(ElementProxy):
     """List of Shape Paths used by |CustomGeometry|.
     """
 
@@ -561,7 +565,9 @@ class PathList(object):
         return ShapePath(self._element._add_path())
 
 
-class ShapePath(object):
+class ShapePath(ElementProxy):
+    """ Individual Shape Paths contained in `a:path`
+    """
     def __init__(self, path):
         super(ShapePath, self).__init__()
         self._element = path
@@ -623,10 +629,6 @@ class ShapePath(object):
 
     def add_cubic_bez_to(self, point1, point2, point3):
         return self._element.add_cubicBezTo(point1, point2, point3)
-
-    @property
-    def xml(self):
-        return self._element.xml
 
     @property
     def path_sequence(self):

--- a/pptx/shapes/picture.py
+++ b/pptx/shapes/picture.py
@@ -179,7 +179,7 @@ class Picture(_BasePicture):
         spPr = self._pic.spPr
         prstGeom = spPr.prstGeom
         if prstGeom is None:
-            spPr._remove_custGeom()
+            spPr._remove_eg_Geometry()
             prstGeom = spPr._add_prstGeom()
         prstGeom.prst = member
 

--- a/pptx/shapes/shapetree.py
+++ b/pptx/shapes/shapetree.py
@@ -344,6 +344,18 @@ class _BaseGroupShapes(_BaseShapes):
 
         return FreeformBuilder.new(self, start_x, start_y, x_scale, y_scale)
 
+    def add_freeform(self, left, top, width, height):
+        """Return new |Shape| object appended to this shape tree.
+
+        *autoshape_type_id* is a member of :ref:`MsoAutoShapeType` e.g.
+        ``MSO_SHAPE.RECTANGLE`` specifying the type of shape to be added. The
+        remaining arguments specify the new shape's position and size.
+        """
+        sp = self._add_freeform(left, top, width, height)
+        self._recalculate_extents()
+        return self._shape_factory(sp)
+
+
     def index(self, shape):
         """Return the index of *shape* in this sequence.
 
@@ -408,6 +420,15 @@ class _BaseGroupShapes(_BaseShapes):
         id_ = self._next_shape_id
         name = "%s %d" % (autoshape_type.basename, id_ - 1)
         sp = self._grpSp.add_autoshape(id_, name, autoshape_type.prst, x, y, cx, cy)
+        return sp
+
+    def _add_freeform(self, x, y, cx, cy):
+        """Return newly-added `p:sp` element as specified.
+
+        `p:sp` element is of freeform type at position (*x*, *y*) and of
+        size (*cx*, *cy*).
+        """
+        sp = self._grpSp.add_freeform_sp(x, y, cx, cy)
         return sp
 
     def _add_textbox_sp(self, x, y, cx, cy):


### PR DESCRIPTION
In order to properly support freeform shapes for the Slide Builder, we needed to be able to read and write all of the various elements for the `<a:custGeom>` tag.  While `python-pptx` has a FreeformBuilder class, it only supports limited bits and pieces and we needed a more complete option.

What I ended up doing was totally leaving that FreeformBuilder on its own and creating a second interface that basically works just for the Slide Importer and Builder.  It lets us access all those components directly but doesn't try to make it that human user friendly.  For our purposes, that is good enough.  It gives us full support and also leaves the existing features as is.  I think it also should give us a huge leap forward to use the SlideBuilder to do the value driver trees though I haven't tried it yet.
