### PR TITLE
D2-543 - Smart Art Basic XML Access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tags
 pyproject.toml
 pip-wheel-metadata/* 
 .vscode/*
+build/*

--- a/pptx/__init__.py
+++ b/pptx/__init__.py
@@ -16,6 +16,13 @@ from pptx.api import Presentation  # noqa
 from pptx.opc.constants import CONTENT_TYPE as CT  # noqa: E402
 from pptx.opc.package import PartFactory  # noqa: E402
 from pptx.parts.chart import ChartPart  # noqa: E402
+from pptx.parts.smartart import (  # noqua: E402
+    SmartArtDrawingPart,
+    SmartArtColorsPart,
+    SmartArtDataPart,
+    SmartArtLayoutPart,
+    SmartArtQuickStylePart,
+)
 from pptx.parts.coreprops import CorePropertiesPart  # noqa: E402
 from pptx.parts.image import ImagePart  # noqa: E402
 from pptx.parts.media import MediaPart  # noqa: E402
@@ -42,6 +49,11 @@ content_type_to_part_class_map = {
     CT.PML_SLIDE_MASTER: SlideMasterPart,
     CT.OFC_THEME: ThemePart,
     CT.DML_CHART: ChartPart,
+    CT.DML_DIAGRAM_DRAWING: SmartArtDrawingPart,
+    CT.DML_DIAGRAM_COLORS: SmartArtColorsPart,
+    CT.DML_DIAGRAM_DATA: SmartArtDataPart,
+    CT.DML_DIAGRAM_LAYOUT: SmartArtLayoutPart,
+    CT.DML_DIAGRAM_STYLE: SmartArtQuickStylePart,
     CT.BMP: ImagePart,
     CT.GIF: ImagePart,
     CT.JPEG: ImagePart,
@@ -72,6 +84,11 @@ del (
     SlidePart,
     SlideLayoutPart,
     SlideMasterPart,
+    SmartArtDrawingPart,
+    SmartArtColorsPart,
+    SmartArtDataPart,
+    SmartArtLayoutPart,
+    SmartArtQuickStylePart,
     PresentationPart,
     CT,
     PartFactory,

--- a/pptx/oxml/__init__.py
+++ b/pptx/oxml/__init__.py
@@ -361,6 +361,7 @@ from .shapes.graphfrm import (  # noqa: E402
     CT_GraphicalObjectFrame,
     CT_GraphicalObjectFrameNonVisual,
     CT_OleObject,
+    CT_RelIds,
 )
 
 register_element_cls("a:graphic", CT_GraphicalObject)
@@ -368,6 +369,7 @@ register_element_cls("a:graphicData", CT_GraphicalObjectData)
 register_element_cls("p:graphicFrame", CT_GraphicalObjectFrame)
 register_element_cls("p:nvGraphicFramePr", CT_GraphicalObjectFrameNonVisual)
 register_element_cls("p:oleObj", CT_OleObject)
+register_element_cls("dgm:relIds", CT_RelIds)
 
 
 from .shapes.groupshape import (  # noqa: E402
@@ -609,3 +611,13 @@ from .media import (
     CT_OfficeArtExtensionList,  # noqa: E402
 )
 register_element_cls("a:extLst", CT_OfficeArtExtensionList)
+
+
+from .diagrams.data import (
+    CT_DataModel,  # noqa: E402
+    CT_DataModelExt,
+    CT_DataModelExtLst,
+)
+register_element_cls("dgm:dataModel", CT_DataModel)
+register_element_cls("dsp:dataModelExt", CT_DataModelExt)
+register_element_cls("dgm:extLst", CT_DataModelExtLst)

--- a/pptx/oxml/diagrams/data.py
+++ b/pptx/oxml/diagrams/data.py
@@ -1,0 +1,36 @@
+# encoding: utf-8
+
+"""Custom element classes for data Diagram-related XML elements."""
+
+from pptx.oxml.xmlchemy import (
+    BaseOxmlElement,
+    RequiredAttribute,
+    ZeroOrMore,
+    ZeroOrOne,
+)
+from pptx.oxml.simpletypes import XsdString
+
+
+class CT_DataModel(BaseOxmlElement):
+    """`dgm:dataModel` custom element class"""
+
+    _tag_seq = (
+        "dgm:ptList",
+        "dgm:cxnLst",
+        "dgm:bg",
+        "dgm:whole",
+        "dgm:extLst",
+    )
+
+    extLst = ZeroOrOne("dgm:extLst")
+
+
+class CT_DataModelExtLst(BaseOxmlElement):
+    """`dgm:extLst` custom element class"""
+    ext = ZeroOrMore("a:ext", successors=())
+
+
+class CT_DataModelExt(BaseOxmlElement):
+    """`dsp:dataModelExt` custom element class"""
+    relId = RequiredAttribute("relId", XsdString)
+

--- a/pptx/oxml/ns.py
+++ b/pptx/oxml/ns.py
@@ -20,6 +20,8 @@ _nsmap = {
     "dc": ("http://purl.org/dc/elements/1.1/"),
     "dcmitype": ("http://purl.org/dc/dcmitype/"),
     "dcterms": ("http://purl.org/dc/terms/"),
+    "dgm": ("http://schemas.openxmlformats.org/drawingml/2006/diagram"),
+    "dsp": ("http://schemas.microsoft.com/office/drawing/2008/diagram"),
     "ep": (
         "http://schemas.openxmlformats.org/officeDocument/2006/extended-p" "roperties"
     ),

--- a/pptx/oxml/shapes/shared.py
+++ b/pptx/oxml/shapes/shared.py
@@ -409,6 +409,7 @@ class CT_PositiveSize2D(BaseOxmlElement):
     """
 
     hyperlinkColor = ZeroOrOne("ahyp:hlinkClr")
+    dataModelExt = ZeroOrOne("dsp:dataModelExt")
 
     cx = RequiredAttribute("cx", ST_PositiveCoordinate)
     cy = RequiredAttribute("cy", ST_PositiveCoordinate)

--- a/pptx/oxml/theme.py
+++ b/pptx/oxml/theme.py
@@ -55,7 +55,7 @@ class CT_BaseStyles(BaseOxmlElement):
         "a:clrScheme",
         "a:fontScheme",
         "a:fmtScheme",
-        "a:extList",
+        "a:extLst",
     )
     clrScheme = OneAndOnlyOne("a:clrScheme")
     fontScheme = OneAndOnlyOne("a:fontScheme")
@@ -100,7 +100,7 @@ class CT_FontScheme(BaseOxmlElement):
     _tag_seq = (
         "a:majorFont",
         "a:minorFont",
-        "a_extList"
+        "a:extLst"
     )
     majorFont = OneAndOnlyOne("a:majorFont")
     minorFont = OneAndOnlyOne("a:minorFont")

--- a/pptx/parts/slide.py
+++ b/pptx/parts/slide.py
@@ -9,6 +9,12 @@ from pptx.opc.packuri import PackURI
 from pptx.oxml.slide import CT_NotesMaster, CT_NotesSlide, CT_Slide
 from pptx.oxml.theme import CT_OfficeStyleSheet
 from pptx.parts.chart import ChartPart
+from pptx.parts.smartart import (
+    SmartArtColorsPart,
+    SmartArtDataPart,
+    SmartArtLayoutPart,
+    SmartArtQuickStylePart,
+)
 from pptx.parts.embeddedpackage import EmbeddedPackagePart
 from pptx.slide import NotesMaster, NotesSlide, Slide, SlideLayout, SlideMaster
 from pptx.util import lazyproperty
@@ -171,6 +177,20 @@ class SlidePart(BaseSlidePart):
         return self.relate_to(
             ChartPart.new(chart_type, chart_data, self._package), RT.CHART
         )
+
+    def add_smart_art_drawing_parts(self, colors_xml, data_xml, layout_xml, style_xml, drawing_xml):
+        """Return str rId of new |SmartArtPart| object.
+        
+        """
+        colors_rId = self.relate_to(SmartArtColorsPart.new(self._package, colors_xml), RT.DIAGRAM_COLORS)
+        data_part, drawing_part = SmartArtDataPart.new(self._package, data_xml, drawing_xml)
+        drawing_rId = self.relate_to(drawing_part, RT.DRAWING)
+        data_part.set_drawing_rId(drawing_rId)
+        data_rId = self.relate_to(data_part, RT.DIAGRAM_DATA)
+        layout_rId = self.relate_to(SmartArtLayoutPart.new(self._package, layout_xml), RT.DIAGRAM_LAYOUT)
+        style_rId = self.relate_to(SmartArtQuickStylePart.new(self._package, style_xml), RT.DIAGRAM_QUICK_STYLE)
+        
+        return drawing_rId, colors_rId, data_rId, layout_rId, style_rId
 
     def add_embedded_ole_object_part(self, prog_id, ole_object_file):
         """Return rId of newly-added OLE-object part formed from `ole_object_file`."""

--- a/pptx/parts/smartart.py
+++ b/pptx/parts/smartart.py
@@ -1,0 +1,98 @@
+# encoding: utf-8
+
+"""Smart Art Parts Objects"""
+
+from pptx.opc.constants import CONTENT_TYPE as CT, RELATIONSHIP_TYPE as RT
+from pptx.opc.package import XmlPart
+from pptx.util import lazyproperty
+
+
+class SmartArtDrawingPart(XmlPart):
+    """A Smart Art Drawing Part
+    Corresponds to parts having partnames matching ppt/diagrams/drawing[1-9][0-9]*.xml
+    """
+    partname_template = "/ppt/diagrams/drawing%d.xml"
+
+    @classmethod
+    def new(cls, package, xml_blob):
+        drawing_part = cls.load(
+            package.next_partname(cls.partname_template),
+            CT.DML_DIAGRAM_DRAWING,
+            package,
+            xml_blob)
+        return drawing_part
+
+
+class SmartArtColorsPart(XmlPart):
+    """A Smart Art Colors Part
+    Corresponds to parts having partnames matching ppt/diagrams/colors[1-9][0-9]*.xml
+    """
+    partname_template = "/ppt/diagrams/colors%d.xml"
+
+    @classmethod
+    def new(cls, package, xml_blob):
+        colors_part = cls.load(
+            package.next_partname(cls.partname_template),
+            CT.DML_DIAGRAM_COLORS,
+            package,
+            xml_blob)
+        return colors_part
+
+class SmartArtDataPart(XmlPart):
+    """A Smart Art Data Part
+    Corresponds to parts having partnames matching ppt/diagrams/data[1-9][0-9]*.xml
+    """
+    partname_template = "/ppt/diagrams/data%d.xml"
+    def __init__(self, partname, content_type, package, element):
+        super(SmartArtDataPart, self).__init__(partname, content_type, package, element)
+
+
+    @classmethod
+    def new(cls, package, data_xml_blob, drawing_xml_blog):
+        data_part = cls.load(
+            package.next_partname(cls.partname_template),
+            CT.DML_DIAGRAM_DATA,
+            package,
+            data_xml_blob)
+
+        drawing_part = SmartArtDrawingPart.new(package, drawing_xml_blog)
+        return data_part, drawing_part
+
+    @property
+    def ext_list(self):
+        return self._element.extLst.ext_lst
+
+    def set_drawing_rId(self, rId):
+       self.ext_list[0].dataModelExt.relId = rId
+
+class SmartArtLayoutPart(XmlPart):
+    """A Smart Art Layout Part
+    Corresponds to parts having partnames matching ppt/diagrams/layout[1-9][0-9]*.xml
+    """
+    partname_template = "/ppt/diagrams/layout%d.xml"
+
+    @classmethod
+    def new(cls, package, xml_blob):
+        layout_part = cls.load(
+            package.next_partname(cls.partname_template),
+            CT.DML_DIAGRAM_LAYOUT,
+            package,
+            xml_blob)
+        return layout_part
+
+
+class SmartArtQuickStylePart(XmlPart):
+    """A Smart Art Quick Style Part
+    Corresponds to parts having partnames matching ppt/diagrams/quickStyle[1-9][0-9]*.xml
+    """
+    partname_template = "/ppt/diagrams/quickStyle%d.xml"
+
+    @classmethod
+    def new(cls, package, xml_blob):
+        style_part = cls.load(
+            package.next_partname(cls.partname_template),
+            CT.DML_DIAGRAM_STYLE,
+            package,
+            xml_blob)
+        return style_part
+

--- a/pptx/shapes/graphfrm.py
+++ b/pptx/shapes/graphfrm.py
@@ -13,6 +13,7 @@ from pptx.spec import (
     GRAPHIC_DATA_URI_CHART,
     GRAPHIC_DATA_URI_OLEOBJ,
     GRAPHIC_DATA_URI_TABLE,
+    GRAPHIC_DATA_URI_DRAWING,
 )
 from pptx.table import Table
 
@@ -39,6 +40,24 @@ class GraphicFrame(BaseShape):
         return self.part.related_part(self._element.chart_rId)
 
     @property
+    def smart_art_parts(self):
+        """The |SmartArtPart| object contianing the smart art in this graphic frame."""
+        parts = {
+            "data": self.part.related_part(self._element.smart_art_data_rId),
+            "layout": self.part.related_part(self._element.smart_art_layout_rId),
+            "style": self.part.related_part(self._element.smart_art_style_rId),
+            "colors": self.part.related_part(self._element.smart_art_colors_rId),
+            "diagram": self.part.related_part(self.smart_art_drawing_part_rId),
+        }
+        return parts
+
+    @property
+    def smart_art_drawing_part_rId(self):
+        data_part = self.part.related_part(self._element.smart_art_data_rId)
+        return data_part.ext_list[0].dataModelExt.relId
+
+
+    @property
     def has_chart(self):
         """|True| if this graphic frame contains a chart object. |False| otherwise.
 
@@ -53,6 +72,14 @@ class GraphicFrame(BaseShape):
         When |True|, the table object can be accessed using the `.table` property.
         """
         return self._element.graphicData_uri == GRAPHIC_DATA_URI_TABLE
+
+    @property
+    def has_smart_art(self):
+        """|True| if this graphic frame contains a smart art object, |False| otherwise.
+
+        When |True|, the smart art object can be accessed using the `.smart_art` property.
+        """
+        return self._element.graphicData_uri == GRAPHIC_DATA_URI_DRAWING
 
     @property
     def ole_format(self):
@@ -93,6 +120,8 @@ class GraphicFrame(BaseShape):
             return MSO_SHAPE_TYPE.CHART
         elif graphicData_uri == GRAPHIC_DATA_URI_TABLE:
             return MSO_SHAPE_TYPE.TABLE
+        elif graphicData_uri == GRAPHIC_DATA_URI_DRAWING:
+            return MSO_SHAPE_TYPE.DIAGRAM
         elif graphicData_uri == GRAPHIC_DATA_URI_OLEOBJ:
             return (
                 MSO_SHAPE_TYPE.EMBEDDED_OLE_OBJECT

--- a/pptx/shapes/shapetree.py
+++ b/pptx/shapes/shapetree.py
@@ -318,6 +318,20 @@ class _BaseGroupShapes(_BaseShapes):
         self._recalculate_extents()
         return self._shape_factory(graphicFrame)
 
+    def add_smart_art(self, drawing_xml, colors_xml, data_xml, layout_xml, quickstyle_xml, x, y, cx, cy):
+        """Return newly-created GraphicFrame shape with a SmartArt object.
+        
+        The Smart Art Object is positioned at (*x*, *y*), has size (*cx*, *cy*), and 
+        is built using the 5 different raw XML strings that are provided here.
+
+        A |GraphicFrame| object is returned.
+        
+        """
+        part_ids = self.part.add_smart_art_drawing_parts(colors_xml, data_xml, layout_xml, quickstyle_xml, drawing_xml)
+        graphicFrame = self._add_smartart_graphicFrame(x, y, cx, cy, part_ids)
+        self._recalculate_extents()
+        return self._shape_factory(graphicFrame)
+
     def add_picture(self, image_file, left, top, width=None, height=None):
         """Add picture shape displaying image in *image_file*.
 
@@ -393,7 +407,6 @@ class _BaseGroupShapes(_BaseShapes):
         self._recalculate_extents()
         return self._shape_factory(sp)
 
-
     def index(self, shape):
         """Return the index of *shape* in this sequence.
 
@@ -412,6 +425,15 @@ class _BaseGroupShapes(_BaseShapes):
         name = "Chart %d" % (shape_id - 1)
         graphicFrame = CT_GraphicalObjectFrame.new_chart_graphicFrame(
             shape_id, name, rId, x, y, cx, cy
+        )
+        self._spTree.append(graphicFrame)
+        return graphicFrame
+
+    def _add_smartart_graphicFrame(self, x, y, cx, cy, rIds):
+        shape_id = self._next_shape_id
+        name = "Diagram %d" % (shape_id - 1)
+        graphicFrame = CT_GraphicalObjectFrame.new_smart_art_graphicFrame(
+            shape_id, name, x, y, cx, cy, rIds[2], rIds[3], rIds[4], rIds[1]
         )
         self._spTree.append(graphicFrame)
         return graphicFrame

--- a/pptx/spec.py
+++ b/pptx/spec.py
@@ -11,7 +11,7 @@ from pptx.enum.shapes import MSO_SHAPE
 GRAPHIC_DATA_URI_CHART = "http://schemas.openxmlformats.org/drawingml/2006/chart"
 GRAPHIC_DATA_URI_OLEOBJ = "http://schemas.openxmlformats.org/presentationml/2006/ole"
 GRAPHIC_DATA_URI_TABLE = "http://schemas.openxmlformats.org/drawingml/2006/table"
-
+GRAPHIC_DATA_URI_DRAWING = "http://schemas.openxmlformats.org/drawingml/2006/diagram"
 
 # ============================================================================
 # AutoShape type specs

--- a/pptx/text/text.py
+++ b/pptx/text/text.py
@@ -525,12 +525,12 @@ class _Hyperlink(Subshape):
 
     def add_hyperlink_color(self):
         """
-        In order to add a color to a single hyperlink, a entry in the extList element
+        In order to add a color to a single hyperlink, a entry in the extLst element
         is required, along with a fill color in the run.  This function must be called
         in order to add the appropriate `ext` element and its `ahyp:hlinkClr` child
         """
-        ext_list = self._rPr.hlinkClick.get_or_add_extLst()
-        ext = ext_list.add_extension()
+        ext_lst = self._rPr.hlinkClick.get_or_add_extLst()
+        ext = ext_lst.add_extension()
         ext.uri = "{A12FA001-AC4F-418D-AE19-62706E023703}"
         hyperlinkColor = ext.get_or_add_hyperlinkColor()
         hyperlinkColor.val = "tx"


### PR DESCRIPTION
There is a lot going on here.  I'll try to give a basic run down but I honestly don't have a completely understanding of everything.

Smart Art objects are held in a Graphic Frame just like Charts and Tables.  Like Charts, the smart art contents are stored in a different, related xml file.  Unlike charts, this is actually 5 different XML files.  4 of those are referenced directly by the slide while the 5th (diagram.xml) is referenced from within the data.xml file.  

My basic approach here was to get enough implementation that I could basically dump each of those 5 files into a string and then reproduce them with the batch tester.  Ultimately, it worked pretty smoothly once I got it all worked out.  

The most complicated part was retrieving and updating the reference to diagram.xml from within data.xml but I eventually got it.  

This is also built so that it can work with D2-523 which makes it work with the slide importer.